### PR TITLE
Add styling to nested and ordered lists

### DIFF
--- a/docs/ios/features/switch-control/index.mdx
+++ b/docs/ios/features/switch-control/index.mdx
@@ -1,0 +1,197 @@
+---
+locale: en
+contentfulID: 5DqfEeCM0JiHmcxkRjC9S2
+type: pageContentPage
+title: Switch Control for iOS
+shortDescription: This article provides in-depth information about using Switch Control to control your iOS device with switches.
+thumbnail: Switch Access icon
+layout: Layout - Assistive technologies
+tag: iOS accessibility feature
+---
+
+Switch control lets you use switches to control your device. This is especially useful for people with a motor disability.
+
+<Image src="/Assets/Blue2 user - Switch control - Image/lightAsset.jpg" alt="Blue2 user - Switch control"/>
+
+*Example of switch control usage.*
+
+## What are switches?
+
+A switch can send an on or off signal to your device. There is support for three types of switches:
+
+- **External switch**: a separate device that sends a signal when pressed. Choose a Bluetooth switch or a Made for iPhone switch.
+- **Screen**: Tap the screen to use a switch or hold your finger on the screen.
+- **Camera**: Move your head to use the iPhone front-facing camera as a switch. You can use the camera as two switches: One when you move your head to the left, and the other when you move your head to the right.
+
+<Image src="/Assets/Blue2 - Switch control - Image/lightAsset.jpg" alt="Blue2 - Switch control"/>
+
+*Example of an external switch: the Blue2 Bluetooth Switch.*
+
+## Set switches
+
+We recommend that you set up switches before turning on switch control. Here are the steps:
+
+### Step 1: Connect Switches
+
+You can add a switch by doing the following:
+
+1. Open the **Settings** app.
+2. Scroll down, and tap **Accessibility**.
+3. Tap **Switch Control**.
+4. Tap **Switches**.
+5. Tap **Add Switch…**
+6. Choose a source:
+   - **External**: Activate a Bluetooth, MIDI, or Made for iPhone auxiliary device.
+   - **Screen**: Choose a switch operation to perform, 'Select item' for example
+   - **Camera**: Choose a switch operation to perform when you move your head left or right.
+7. Follow the instructions on the screen to set the switch.
+
+### Step 2: Set scan method
+
+There are three different ways in which the focus can be moved. If you use one switch, you can only choose **automatic scanning**. With two or more switches, you can also choose **manual scanning** and **step scanning**.
+
+To choose the scanning method:
+
+1. Open the **Settings** app.
+2. Scroll down, and tap **Accessibility**.
+3. Tap **Switch Control**.
+4. Tap **Scan method**.
+5. Choose the desired scanning method.
+
+### Step 3: Activate Speech
+
+Note: This step is optional. If you want the element to be read with focus, you can turn on speech.
+
+1. Open the **Settings** app.
+2. Scroll down, and tap **Accessibility**.
+3. Tap **Switch Control**.
+4. Tap **Speech**.
+5. Turn on the switch.
+   - You can also choose a voice and adjust the speaking rate here.
+
+## Enable Switch Control
+
+You can enable switch control in two ways.
+
+### **Way 1**: via settings
+
+1. Open the **Settings** app
+2. Tap **Accessibility**
+3. Tap **Switch Control**
+4. Turn on the **switch**
+
+### **Way 2**: Via Shortcut
+
+1. Open the **Settings** app
+2. Tap **Accessibility**
+3. Scroll down, tap **Accessibility shortcut**
+4. Tap **Switch Control**
+5. Press the **side button** or **home button three times**
+
+It is **not** possible to enable switch control via Siri.
+
+## Disable Switch Control
+
+Turning off switch controls is a challenge as you have to navigate through the switches you set. It is **not** possible to disable switch control via Siri.
+
+The easiest way to disable switch control is via the shortcut. This only works if you've set up a switch control shortcut. Activate the shortcut by pressing the side button or home button three times.
+
+If you haven't set a shortcut, the only way is through the Settings app:
+
+1. Ask Siri: *“Hey Siri, open the accessibility settings”*.
+   - If this fails, follow these additional steps:
+      1. Press switch. Highlight **More**. Highlight **Home**.
+      2. Highlight **Pages**. Press switch. Highlight **Decrease** or **Increase**. Press switch.
+         - Repeat until you see the Settings app.
+      3. Highlight the **Settings app**. Press switch. Highlight **Tap**. Press switch.
+      4. Highlight the **General group**. Press switch.
+      5. Highlight **General**. Press switch.
+      6. Highlight **Accessibility**. Press switch. Highlight **Tap**. Press switch.
+2. Highlight **Touch**. Press switch. Highlight **Tap**. Press switch.
+3. Highlight **Switch Control**. Press switch. Highlight **Tap**. Press switch.
+4. Highlight the **Switch Control switch**. Press switch. Highlight **Tap**. Press Switch.
+5. Finally, mark **Yes**. Press switch. Choose **Tap**.
+
+Switch control is now off!
+
+## Using Switch Control
+
+There are three ways to select items on the screen: item scan, point scan, and manual selection. The most standard way of selecting is item scanning. Unfortunately, you have to keep in mind that not all apps support switch control.
+
+### Use item scanning
+
+Item scanning highlights items or groups on the screen one at a time. Here's how to use item scanning:
+
+- To select an item or a group, watch (or listen) as items are highlighted. While an item is highlighted, choose it with the switch that you set up as your Select Item switch. When you select a group, highlighting continues with the items in the group. 
+- To exit a group, use your switch when the dashed highlight around the group or item appears.
+
+<Image src="/Assets/Onderdeelscannen - Switch control - Image/lightAsset.jpg" alt="Onderdeelscannen - Switch control - iOS"/>
+
+*Preview of a selected item via item scanning.*
+
+### Use point scanning
+
+Point scanning lets you select an item on the screen by pinpointing it with scanning crosshairs. To turn on point scanning:
+
+1. Use item scanning to select an item. 
+2. Wait for the menu to appear.
+3. Select Point Mode. The wide vertical crosshairs appear when you close the menu.
+
+To select an item with point scanning: 
+
+1. Use your select switch to stop the wide vertical crosshairs. The fine vertical crosshair appears.
+2. Use your select switch again to stop the fine vertical crosshair. The fine scanning line will appear next.
+3. Repeat to stop and refine the vertical crosshairs.
+
+To turn off point scanning: 
+
+1. Use point scanning to select an item.
+2. Wait for the menu to appear. 
+3. Select Item Mode.
+
+<Image src="/Assets/Puntscannen - Switch control - Image/lightAsset.jpg" alt="Puntscannen - Switch control - iOS"/>
+
+*Cross-pointer example via point scanning.*
+
+### Use manual scanning
+
+If you use multiple switches, you can set up each switch to perform a specific action and customize how you select items. For example, instead of automatically scanning items, you can set up switches to move to the next or previous item on demand. If you just have one switch, keep using Auto Scanning. To use manual scanning:
+
+1. Go to **Settings**
+2. Tap **Accessibility**
+3. Tap **Switch Control**.
+4. Tap **Scanning Style**
+5. Select **Manual Scanning**.
+
+<Image src="/Assets/Meerdere schakelaars - Switch control - Image/lightAsset.png" alt="Meerdere schakelaars - Switch control - iOS"/>
+
+*Example with several connected switches.*
+
+## Switch control menu
+
+When you have selected an item, a menu is displayed with the options for that item. Select the dots at the bottom of the menu to view more options.
+
+The following options are available:
+
+- Click the Home button.
+- Double-click the Home button for multitasking.
+- Open Notification Center or Control Center.
+- Press the Sleep/Wake button to lock the device.
+- Rotate the device.
+- Flip the Mute switch.
+- Press the volume buttons.
+- Hold down the Home button to open Siri.
+- Triple-click the Home button.
+- Shake the device.
+- Press Home and Sleep/Wake buttons simultaneously to take a screenshot.
+
+<Image src="/Assets/Schakelbediening menu - Switch control - Image/lightAsset.jpg" alt="Schakelbediening menu - Switch control - iOS"/>
+
+*Here you will find the switch control menu.*
+
+## Learn switch control
+
+Want to learn even more about using switch control? Apple has written several guides:
+
+- [Using Switch Control to Navigate](https://support.apple.com/en-us/HT201370)
+- [Use Switch Control to control another Apple device](https://support.apple.com/en-us/HT205644)

--- a/src/css/globals.css
+++ b/src/css/globals.css
@@ -1,5 +1,5 @@
-@import './prism/a11y-light.css';
-@import './prism/a11y-dark.css';
+@import "./prism/a11y-light.css";
+@import "./prism/a11y-dark.css";
 
 @tailwind base;
 @tailwind components;
@@ -104,6 +104,17 @@ main.container {
   max-width: max-content;
   padding: 0;
   margin-top: 0 !important;
+}
+
+/* Unordered lists cannot be swizzled */
+.markdown ol {
+  max-width: theme(maxWidth.md);
+  list-style-type: decimal;
+}
+
+.markdown ol li {
+  margin-top: theme(spacing.4);
+  margin-left: theme(spacing.7);
 }
 
 main.container > .row > .col.col--8 {


### PR DESCRIPTION
* Ordered lists didn't have any numbers in front of them because of some default Docusaurus styling
* Tested with newly provided data that outputs nested lists correctly
* http://localhost:3000/docs/ios/features/switch-control/