### PR TITLE
Feature/code contribute

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -11,6 +11,10 @@
     "message": "Copy",
     "description": "The copy button label on code blocks"
   },
+  "theme.CodeBlock.contribute": {
+    "message": "Contribute",
+    "description": "The contribute link label on code blocks"
+  },
   "theme.ErrorPageContent.title": {
     "message": "Oops, something went wrong.",
     "description": "The title of the fallback page when the page crashed"

--- a/i18n/nl/code.json
+++ b/i18n/nl/code.json
@@ -11,6 +11,10 @@
     "message": "Kopieer",
     "description": "The copy button label on code blocks"
   },
+  "theme.CodeBlock.contribute": {
+    "message": "Bijdragen",
+    "description": "The contribute link label on code blocks"
+  },
   "theme.ErrorPageContent.title": {
     "message": "Oeps! Er is iets misgegaan.",
     "description": "The title of the fallback page when the page crashed"

--- a/src/components/CodeSample/index.tsx
+++ b/src/components/CodeSample/index.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
+import MDXCode from '@theme/MDXComponents/Code'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import clsx from 'clsx';
-
+import React from 'react';
 import styles from './styles.module.css';
 
 export type CodeSampleProps = {
@@ -15,11 +16,11 @@ export function CodeSample({ id, platform }: CodeSampleProps) {
   const defaultPlatforms = [
     'android',
     'jetpack-compose',
-    'ios', 
-    'swiftui', 
-    'flutter', 
+    'ios',
+    'swiftui',
+    'flutter',
     'react-native',
-    'net-maui', 
+    'net-maui',
     'xamarin'
   ];
   const platformLabels = [
@@ -41,11 +42,26 @@ export function CodeSample({ id, platform }: CodeSampleProps) {
       const codeBlocks = [...platforms].map(async platform => {
         try {
           const module = await import(`@site/src/data/code-samples/en/${id}/${platform}.md`);
+          const url = `https://github.com/appt-org/appt-website/tree/develop/src/data/code-samples/en/${id}/${platform}.md?plain=1`
+
+          // Inject `url` in metastring, used in `CodeBlockString` function
+          const components = {
+            code: (props) => {
+              const urlMeta = `url="${url}"`
+              const metastring = props.metastring ? `${props.metastring} ${urlMeta}` : urlMeta
+
+              return <MDXCode {...props} metastring={metastring}>
+                {props.children}
+              </MDXCode>
+            }
+          }
 
           return {
-            platform,
-            platformLabel: platformLabels.find(label => label.id === platform).label,
-            CodeBlock: module.default,
+            id: id,
+            platform: platform,
+            label: platformLabels.find(label => label.id === platform).label,
+            url: url,
+            content: <module.default components={components}/>
           };
         } catch (error) {
           console.error('Failed to import MDX content:', error);
@@ -71,13 +87,13 @@ export function CodeSample({ id, platform }: CodeSampleProps) {
         {codeBlocks.length > 1 && (
           <Tabs className={styles.codeSampleTabs} groupId="platform" queryString>
             {codeBlocks.map((codeBlock, index) => (
-              <TabItem key={index} value={codeBlock.platform} label={codeBlock.platformLabel}>
-                <codeBlock.CodeBlock />
+              <TabItem key={index} value={codeBlock.platform} label={codeBlock.label}>
+                {codeBlock.content}
               </TabItem>
             ))}
           </Tabs>
         )}
-        {codeBlocks.length === 1 && <firstCodeBlock.CodeBlock />}
+        {codeBlocks.length === 1 && firstCodeBlock.content}
       </div>
     );
   }

--- a/src/theme/CodeBlock/Content/String.tsx
+++ b/src/theme/CodeBlock/Content/String.tsx
@@ -50,10 +50,8 @@ export default function CodeBlockString({
   metastring,
   title: titleProp,
   showLineNumbers: showLineNumbersProp,
-  language: languageProp
+  language: languageProp,
 }: Props): JSX.Element {
-  console.log("Metastring", metastring)
-
   const {
     prism: { defaultLanguage, magicComments },
   } = useThemeConfig();

--- a/src/theme/CodeBlock/Content/String.tsx
+++ b/src/theme/CodeBlock/Content/String.tsx
@@ -10,8 +10,11 @@ import Container from '@theme/CodeBlock/Container';
 import type { Props } from '@theme/CodeBlock/Content/String';
 import CopyButton from '@theme/CodeBlock/CopyButton';
 import Line from '@theme/CodeBlock/Line';
-import clsx from 'clsx';
+import Link from '@docusaurus/Link';
 import { Highlight, type Language } from 'prism-react-renderer';
+
+import clsx from 'clsx';
+import { translate } from '@docusaurus/Translate';
 
 import styles from './styles.module.css';
 
@@ -112,7 +115,17 @@ export default function CodeBlockString({
         <div className={clsx(styles.buttonGroup, 'p-4')}>
           <CopyButton code={code} />
 
-          {url && <a href={url} target="_blank" rel="noopener noreferrer">Contribute</a>}
+          {url && 
+            <Link 
+              to={url} 
+              target="_blank" 
+              className={clsx(
+                'clean-btn', 
+                'rounded-lg text-accent inline-flex items-center bg-onsurface p-3'
+              )} >
+                {translate({id: 'theme.CodeBlock.contribute'})}
+            </Link>
+          }
         </div>
       </div>
     </Container>

--- a/src/theme/CodeBlock/Content/String.tsx
+++ b/src/theme/CodeBlock/Content/String.tsx
@@ -35,14 +35,22 @@ function normalizeLanguage(language: string | undefined): string | undefined {
   return language?.toLowerCase();
 }
 
+const urlRegex = /url=['"](.*?)['"]/;
+
+function parseUrl(metastring?: string): string {
+  return metastring?.match(urlRegex)?.[1]
+}
+
 export default function CodeBlockString({
   children,
   className: blockClassName = '',
   metastring,
   title: titleProp,
   showLineNumbers: showLineNumbersProp,
-  language: languageProp,
+  language: languageProp
 }: Props): JSX.Element {
+  console.log("Metastring", metastring)
+
   const {
     prism: { defaultLanguage, magicComments },
   } = useThemeConfig();
@@ -62,6 +70,8 @@ export default function CodeBlockString({
     magicComments,
   });
   const showLineNumbers = showLineNumbersProp ?? containsLineNumbers(metastring);
+
+  const url = parseUrl(metastring);
 
   return (
     <Container
@@ -101,6 +111,8 @@ export default function CodeBlockString({
         </Highlight>
         <div className={clsx(styles.buttonGroup, 'p-4')}>
           <CopyButton code={code} />
+
+          {url && <a href={url} target="_blank" rel="noopener noreferrer">Contribute</a>}
         </div>
       </div>
     </Container>


### PR DESCRIPTION
#### What does this PR do?

Adds a Contribute button to all code blocks.

If I understand correctly, the `CodeBlock` component from Docusaurus has been swizzled in our project. The `CodeBlockString` function has been modified to generate our desired output.

I needed to pass the `url` of the source Markdown file down from the `CodeSample` component. One of the ways to achieve this is to injecting data into the `metastring` prop. The `metastring` is based on the text that follows after inserting a code block, e.g.

```md
```md title="Markdown.md" url="https://www.markdownguide.org/"
# Title
This is markdown, it's metastring contains a title and url
```

The metastring is already used to pass down data, I figured it made most sense to add support for `url`.

To achieve the injection, I have used the `components={components}` prop to override the default component used to render `code`. In my override, it extends the metastring with the url metadata.

In the `CodeBlockString` function, the metastring is parsed, I have added a new parsing method for url. If a url has been passed, a `Link` is rendered next to the copy button.

If there is a cleaner way to achieve this, please let me know.

#### How do you test this PR?

Test link:

1. Navigate to http://localhost:3000/en/guidelines/wcag/success-criterion-4-1-2#solution
2. Check if you see a Contribute button next to the Copy button in the code block
3. Check if the contribute button links to the right Markdown file, e.g. https://github.com/appt-org/appt-website/blob/develop/src/data/code-samples/en/accessibility-name/android.md for Android accessibility-name
4. Repeat steps above for more platforms and different code samples

#### Checklist

- [X] Works on Safari, Chrome, Firefox & Edge
- [X] Works on different screen sizes (responsive)
- [X] Scores 100 in [Lighthouse/PageSpeed Insights](https://pagespeed.web.dev) on SEO, accessibility and best practices, and >= 90 on performance
- [X] Does not contain tracking cookies
- [/] Are migrations added?
- [/] Is the README.md updated?

**Accessibility checklist**

- Scalable text
- Dark and light mode
- Contrast
- Focus management
- Aria attributes
