### PR TITLE
Fix color contrast issue in SwiftUI code snippets

### DIFF
--- a/src/css/prism/a11y-dark.css
+++ b/src/css/prism/a11y-dark.css
@@ -10,124 +10,128 @@
 /*
  Theme
  */
-[data-theme="dark"] code[class*="language-"],
-[data-theme="dark"] pre[class*="language-"] {
-  color: #ffffff!important;
+[data-theme='dark'] code[class*='language-'],
+[data-theme='dark'] pre[class*='language-'] {
+  color: #ffffff !important;
   background: none;
-  font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace!important;
-  font-size: 0.9rem!important;
-  text-align: left!important;
-  white-space: pre!important;
-  word-spacing: normal!important;
-  word-break: normal!important;
-  word-wrap: normal!important;
-  line-height: 1.5!important;
+  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace !important;
+  font-size: 0.9rem !important;
+  text-align: left !important;
+  white-space: pre !important;
+  word-spacing: normal !important;
+  word-break: normal !important;
+  word-wrap: normal !important;
+  line-height: 1.5 !important;
 
-  -moz-tab-size: 4!important;
-  -o-tab-size: 4!important;
-  tab-size: 4!important;
+  -moz-tab-size: 4 !important;
+  -o-tab-size: 4 !important;
+  tab-size: 4 !important;
 
-  -webkit-hyphens: none!important;
-  -moz-hyphens: none!important;
-  -ms-hyphens: none!important;
-  hyphens: none!important;
+  -webkit-hyphens: none !important;
+  -moz-hyphens: none !important;
+  -ms-hyphens: none !important;
+  hyphens: none !important;
 }
 
-[data-theme="dark"] .token.plain {
-  color: #ffffff!important;
+[data-theme='dark'] .token.plain {
+  color: #ffffff !important;
 }
 
-[data-theme="dark"] .token.comment {
-  font-size: 0.9rem!important;
+[data-theme='dark'] .token.comment {
+  font-size: 0.9rem !important;
 }
 
 /* Code blocks */
-[data-theme="dark"] pre[class*="language-"] {
-  padding: 1em!important;
-  margin: 0!important;
-  overflow: auto!important;
+[data-theme='dark'] pre[class*='language-'] {
+  padding: 1em !important;
+  margin: 0 !important;
+  overflow: auto !important;
 }
 
 /* Inline code */
-[data-theme="dark"] :not(pre) > code[class*="language-"] {
-  padding: 0.1em!important;
-  border-radius: 0.3em!important;
-  white-space: normal!important;
+[data-theme='dark'] :not(pre) > code[class*='language-'] {
+  padding: 0.1em !important;
+  border-radius: 0.3em !important;
+  white-space: normal !important;
 }
 
-[data-theme="dark"] .token.comment,
-[data-theme="dark"] .token.prolog,
-[data-theme="dark"] .token.doctype,
-[data-theme="dark"] .token.cdata {
-  color: #d4d0ab!important;
+[data-theme='dark'] .token.comment,
+[data-theme='dark'] .token.prolog,
+[data-theme='dark'] .token.doctype,
+[data-theme='dark'] .token.cdata {
+  color: #d4d0ab !important;
 }
 
-[data-theme="dark"] .token.punctuation {
-  color: #fefefe!important;
+[data-theme='dark'] .token.punctuation {
+  color: #fefefe !important;
 }
 
-[data-theme="dark"] .token.namespace {
-  opacity: 0.7!important;
+[data-theme='dark'] .token.namespace {
+  opacity: 0.7 !important;
 }
 
-[data-theme="dark"] .token.property,
-[data-theme="dark"] .token.tag,
-[data-theme="dark"] .token.constant,
-[data-theme="dark"] .token.class-name,
-[data-theme="dark"] .token.symbol,
-[data-theme="dark"] .token.deleted {
-  color: #ffa07a!important;
+[data-theme='dark'] .token.property,
+[data-theme='dark'] .token.tag,
+[data-theme='dark'] .token.constant,
+[data-theme='dark'] .token.class-name,
+[data-theme='dark'] .token.symbol,
+[data-theme='dark'] .token.deleted {
+  color: #ffa07a !important;
 }
 
-[data-theme="dark"] .token.boolean,
-[data-theme="dark"] .token.number {
-  color: #00e0e0!important;
+[data-theme='dark'] .token.boolean,
+[data-theme='dark'] .token.number {
+  color: #00e0e0 !important;
 }
 
-[data-theme="dark"] .token.selector,
-[data-theme="dark"] .token.attr-name,
-[data-theme="dark"] .token.string,
-[data-theme="dark"] .token.char,
-[data-theme="dark"] .token.builtin,
-[data-theme="dark"] .token.inserted {
-  color: #abe338!important;
+[data-theme='dark'] .token.selector,
+[data-theme='dark'] .token.attr-name,
+[data-theme='dark'] .token.string,
+[data-theme='dark'] .token.char,
+[data-theme='dark'] .token.builtin,
+[data-theme='dark'] .token.inserted {
+  color: #abe338 !important;
 }
 
-[data-theme="dark"] .token.operator,
-[data-theme="dark"] .token.entity,
-[data-theme="dark"] .token.url,
-[data-theme="dark"] .language-css .token.string,
-[data-theme="dark"] .style .token.string,
-[data-theme="dark"] .token.variable {
-  color: #00e0e0!important;
+[data-theme='dark'] .token.operator,
+[data-theme='dark'] .token.entity,
+[data-theme='dark'] .token.url,
+[data-theme='dark'] .language-css .token.string,
+[data-theme='dark'] .style .token.string,
+[data-theme='dark'] .token.variable {
+  color: #00e0e0 !important;
 }
 
-[data-theme="dark"] .token.atrule,
-[data-theme="dark"] .token.attr-value,
-[data-theme="dark"] .token.function {
-  color: #ffd700!important;
+[data-theme='dark'] .token.atrule,
+[data-theme='dark'] .token.attr-value,
+[data-theme='dark'] .token.function {
+  color: #ffd700 !important;
 }
 
-[data-theme="dark"] .token.keyword {
-  color: #00e0e0!important;
+[data-theme='dark'] .token.keyword {
+  color: #00e0e0 !important;
 }
 
-[data-theme="dark"] .token.regex,
-[data-theme="dark"] .token.important {
-  color: #ffd700!important;
+[data-theme='dark'] .token.regex,
+[data-theme='dark'] .token.important {
+  color: #ffd700 !important;
 }
 
-[data-theme="dark"] .token.important,
-[data-theme="dark"] .token.bold {
-  font-weight: bold!important;
+[data-theme='dark'] .token.important,
+[data-theme='dark'] .token.bold {
+  font-weight: bold !important;
 }
 
-[data-theme="dark"] .token.italic {
-  font-style: italic!important;
+[data-theme='dark'] .token.italic {
+  font-style: italic !important;
 }
 
-[data-theme="dark"] .token.entity {
-  cursor: help!important;
+[data-theme='dark'] .token.entity {
+  cursor: help !important;
+}
+
+[data-theme='dark'] .interpolation {
+  color: rgb(248, 248, 242);
 }
 
 /*
@@ -135,64 +139,64 @@
  */
 
 /* Line highlight */
-[data-theme="dark"] .line-highlight {
-  background: rgba(255, 217, 0, 0.1)!important;
-  border-top: 1px solid rgba(255, 217, 0, 0.55)!important;
-  border-bottom: 1px solid rgba(255, 217, 0, 0.55)!important;
+[data-theme='dark'] .line-highlight {
+  background: rgba(255, 217, 0, 0.1) !important;
+  border-top: 1px solid rgba(255, 217, 0, 0.55) !important;
+  border-bottom: 1px solid rgba(255, 217, 0, 0.55) !important;
 }
 
 /* Line numbers */
-[data-theme="dark"] .line-numbers .line-numbers-rows {
-  border-right: 1px solid #f8f8f2!important;
+[data-theme='dark'] .line-numbers .line-numbers-rows {
+  border-right: 1px solid #f8f8f2 !important;
 }
 
-[data-theme="dark"] .line-numbers-rows > span:before {
-  color: #d4d0ab!important;
+[data-theme='dark'] .line-numbers-rows > span:before {
+  color: #d4d0ab !important;
 }
 
 /*
  High contrast mode support
 */
 @media screen and (-ms-high-contrast: active) {
-  [data-theme="dark"] code[class*="language-"],
-  [data-theme="dark"] pre[class*="language-"] {
-    color: windowText!important;
-    background: window!important;
+  [data-theme='dark'] code[class*='language-'],
+  [data-theme='dark'] pre[class*='language-'] {
+    color: windowText !important;
+    background: window !important;
   }
 
-  [data-theme="dark"] :not(pre) > code[class*="language-"],
-  [data-theme="dark"] pre[class*="language-"] {
-    background: window!important;
+  [data-theme='dark'] :not(pre) > code[class*='language-'],
+  [data-theme='dark'] pre[class*='language-'] {
+    background: window !important;
   }
 
-  [data-theme="dark"] .token.important {
-    background: highlight!important;
-    color: window!important;
-    font-weight: normal!important;
+  [data-theme='dark'] .token.important {
+    background: highlight !important;
+    color: window !important;
+    font-weight: normal !important;
   }
 
-  [data-theme="dark"] .token.atrule,
-  [data-theme="dark"] .token.attr-value,
-  [data-theme="dark"] .token.function,
-  [data-theme="dark"] .token.keyword,
-  [data-theme="dark"] .token.operator,
-  [data-theme="dark"] .token.selector {
-    font-weight: bold!important;
+  [data-theme='dark'] .token.atrule,
+  [data-theme='dark'] .token.attr-value,
+  [data-theme='dark'] .token.function,
+  [data-theme='dark'] .token.keyword,
+  [data-theme='dark'] .token.operator,
+  [data-theme='dark'] .token.selector {
+    font-weight: bold !important;
   }
 
-  [data-theme="dark"] .token.attr-value,
-  [data-theme="dark"] .token.comment,
-  [data-theme="dark"] .token.doctype,
-  [data-theme="dark"] .token.function,
-  [data-theme="dark"] .token.keyword,
-  [data-theme="dark"] .token.operator,
-  [data-theme="dark"] .token.property,
-  [data-theme="dark"] .token.string {
-    color: highlight!important;
+  [data-theme='dark'] .token.attr-value,
+  [data-theme='dark'] .token.comment,
+  [data-theme='dark'] .token.doctype,
+  [data-theme='dark'] .token.function,
+  [data-theme='dark'] .token.keyword,
+  [data-theme='dark'] .token.operator,
+  [data-theme='dark'] .token.property,
+  [data-theme='dark'] .token.string {
+    color: highlight !important;
   }
 
-  [data-theme="dark"] .token.attr-value,
-  [data-theme="dark"] .token.url {
-    font-weight: normal!important;
+  [data-theme='dark'] .token.attr-value,
+  [data-theme='dark'] .token.url {
+    font-weight: normal !important;
   }
 }

--- a/src/css/prism/a11y-light.css
+++ b/src/css/prism/a11y-light.css
@@ -10,64 +10,64 @@
 /*
  Theme
  */
-code[class*="language-"],
-pre[class*="language-"] {
-  color: #202020!important;
-  background: none!important;
-  font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace!important;
-  font-size: 0.9rem!important;
-  text-align: left!important;
-  white-space: pre!important;
-  word-spacing: normal!important;
-  word-break: normal!important;
-  word-wrap: normal!important;
-  line-height: 1.5!important;
+code[class*='language-'],
+pre[class*='language-'] {
+  color: #202020 !important;
+  background: none !important;
+  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace !important;
+  font-size: 0.9rem !important;
+  text-align: left !important;
+  white-space: pre !important;
+  word-spacing: normal !important;
+  word-break: normal !important;
+  word-wrap: normal !important;
+  line-height: 1.5 !important;
 
-  -moz-tab-size: 4!important;
-  -o-tab-size: 4!important;
-  tab-size: 4!important;
+  -moz-tab-size: 4 !important;
+  -o-tab-size: 4 !important;
+  tab-size: 4 !important;
 
-  -webkit-hyphens: none!important;
-  -moz-hyphens: none!important;
-  -ms-hyphens: none!important;
-  hyphens: none!important;
+  -webkit-hyphens: none !important;
+  -moz-hyphens: none !important;
+  -ms-hyphens: none !important;
+  hyphens: none !important;
 }
 
 .token.plain {
-  color: #202020!important;
+  color: #202020 !important;
 }
 
 .token.comment {
-  font-size: 0.9rem!important;
+  font-size: 0.9rem !important;
 }
 
 /* Code blocks */
-pre[class*="language-"] {
-  padding: 1em!important;
-  margin: 0!important;
-  overflow: auto!important;
+pre[class*='language-'] {
+  padding: 1em !important;
+  margin: 0 !important;
+  overflow: auto !important;
 }
 
 /* Inline code */
-:not(pre) > code[class*="language-"] {
-  padding: 0.1em!important;
-  border-radius: 0.3em!important;
-  white-space: normal!important;
+:not(pre) > code[class*='language-'] {
+  padding: 0.1em !important;
+  border-radius: 0.3em !important;
+  white-space: normal !important;
 }
 
 .token.comment,
 .token.prolog,
 .token.doctype,
 .token.cdata {
-  color: #696969!important;
+  color: #696969 !important;
 }
 
 .token.punctuation {
-  color: #000000!important;
+  color: #000000 !important;
 }
 
 .token.namespace {
-  opacity: 0.7!important;
+  opacity: 0.7 !important;
 }
 
 .token.property,
@@ -76,12 +76,12 @@ pre[class*="language-"] {
 .token.class-name,
 .token.symbol,
 .token.deleted {
-  color: #007299!important;
+  color: #007299 !important;
 }
 
 .token.boolean,
 .token.number {
-  color: #008000!important;
+  color: #008000 !important;
 }
 
 .token.selector,
@@ -90,7 +90,7 @@ pre[class*="language-"] {
 .token.char,
 .token.builtin,
 .token.inserted {
-  color: #aa5d00!important;
+  color: #aa5d00 !important;
 }
 
 .token.operator,
@@ -99,35 +99,39 @@ pre[class*="language-"] {
 .language-css .token.string,
 .style .token.string,
 .token.variable {
-  color: #008000!important;
+  color: #008000 !important;
 }
 
 .token.atrule,
 .token.attr-value,
 .token.function {
-  color: #aa5d00!important;
+  color: #aa5d00 !important;
 }
 
 .token.keyword {
-  color: #d91e18!important;
+  color: #d91e18 !important;
 }
 
 .token.regex,
 .token.important {
-  color: #d91e18!important;
+  color: #d91e18 !important;
 }
 
 .token.important,
 .token.bold {
-  font-weight: bold!important;
+  font-weight: bold !important;
 }
 
 .token.italic {
-  font-style: italic!important;
+  font-style: italic !important;
 }
 
 .token.entity {
-  cursor: help!important;
+  cursor: help !important;
+}
+
+.interpolation {
+  color: rgb(7, 7, 13);
 }
 
 /*
@@ -136,39 +140,39 @@ pre[class*="language-"] {
 
 /* Line highlight */
 .line-highlight {
-  background: rgba(183, 134, 11, 0.075)!important;
-  border-top: 1px solid #b8860b!important;
-  border-bottom: 1px solid #b8860b!important;
+  background: rgba(183, 134, 11, 0.075) !important;
+  border-top: 1px solid #b8860b !important;
+  border-bottom: 1px solid #b8860b !important;
 }
 
 /* Line numbers */
 .line-numbers .line-numbers-rows {
-  border-right: 1px solid #aa5d00!important;
+  border-right: 1px solid #aa5d00 !important;
 }
 
 .line-numbers-rows > span:before {
-  color: #696969!important;
+  color: #696969 !important;
 }
 
 /*
  High contrast mode support
 */
 @media screen and (-ms-high-contrast: active) {
-  code[class*="language-"],
-  pre[class*="language-"] {
-    color: windowText!important;
-    background: window!important;
+  code[class*='language-'],
+  pre[class*='language-'] {
+    color: windowText !important;
+    background: window !important;
   }
 
-  :not(pre) > code[class*="language-"],
-  pre[class*="language-"] {
-    background: window!important;
+  :not(pre) > code[class*='language-'],
+  pre[class*='language-'] {
+    background: window !important;
   }
 
   .token.important {
-    background: highlight!important;
-    color: window!important;
-    font-weight: normal!important;
+    background: highlight !important;
+    color: window !important;
+    font-weight: normal !important;
   }
 
   .token.atrule,
@@ -177,7 +181,7 @@ pre[class*="language-"] {
   .token.keyword,
   .token.operator,
   .token.selector {
-    font-weight: bold!important;
+    font-weight: bold !important;
   }
 
   .token.attr-value,
@@ -188,11 +192,11 @@ pre[class*="language-"] {
   .token.operator,
   .token.property,
   .token.string {
-    color: highlight!important;
+    color: highlight !important;
   }
 
   .token.attr-value,
   .token.url {
-    font-weight: normal!important;
+    font-weight: normal !important;
   }
 }

--- a/src/data/generated/data-features/android-accessibility_features-1+.json
+++ b/src/data/generated/data-features/android-accessibility_features-1+.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility features - 1+","feature_key":"accessibility_features","property_key":"1+","platform":"android","amount":5057812,"percentage":63.37}
+{"name":"Android - Accessibility features - 1+","feature_key":"accessibility_features","property_key":"1+","platform":"android","amount":5063301,"percentage":63.38}

--- a/src/data/generated/data-features/android-accessibility_features-1+.json
+++ b/src/data/generated/data-features/android-accessibility_features-1+.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility features - 1+","feature_key":"accessibility_features","property_key":"1+","platform":"android","amount":5046458,"percentage":63.33}
+{"name":"Android - Accessibility features - 1+","feature_key":"accessibility_features","property_key":"1+","platform":"android","amount":5050734,"percentage":63.35}

--- a/src/data/generated/data-features/android-accessibility_features-1+.json
+++ b/src/data/generated/data-features/android-accessibility_features-1+.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility features - 1+","feature_key":"accessibility_features","property_key":"1+","platform":"android","amount":5063301,"percentage":63.38}
+{"name":"Android - Accessibility features - 1+","feature_key":"accessibility_features","property_key":"1+","platform":"android","amount":5069216,"percentage":63.4}

--- a/src/data/generated/data-features/android-accessibility_features-1+.json
+++ b/src/data/generated/data-features/android-accessibility_features-1+.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility features - 1+","feature_key":"accessibility_features","property_key":"1+","platform":"android","amount":5050734,"percentage":63.35}
+{"name":"Android - Accessibility features - 1+","feature_key":"accessibility_features","property_key":"1+","platform":"android","amount":5057812,"percentage":63.37}

--- a/src/data/generated/data-features/android-accessibility_features-2+.json
+++ b/src/data/generated/data-features/android-accessibility_features-2+.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility features - 2+","feature_key":"accessibility_features","property_key":"2+","platform":"android","amount":2124847,"percentage":26.19}
+{"name":"Android - Accessibility features - 2+","feature_key":"accessibility_features","property_key":"2+","platform":"android","amount":2127322,"percentage":26.2}

--- a/src/data/generated/data-features/android-accessibility_features-2+.json
+++ b/src/data/generated/data-features/android-accessibility_features-2+.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility features - 2+","feature_key":"accessibility_features","property_key":"2+","platform":"android","amount":2127322,"percentage":26.2}
+{"name":"Android - Accessibility features - 2+","feature_key":"accessibility_features","property_key":"2+","platform":"android","amount":2131320,"percentage":26.23}

--- a/src/data/generated/data-features/android-accessibility_features-2+.json
+++ b/src/data/generated/data-features/android-accessibility_features-2+.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility features - 2+","feature_key":"accessibility_features","property_key":"2+","platform":"android","amount":2133906,"percentage":26.23}
+{"name":"Android - Accessibility features - 2+","feature_key":"accessibility_features","property_key":"2+","platform":"android","amount":2136761,"percentage":26.25}

--- a/src/data/generated/data-features/android-accessibility_features-2+.json
+++ b/src/data/generated/data-features/android-accessibility_features-2+.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility features - 2+","feature_key":"accessibility_features","property_key":"2+","platform":"android","amount":2131320,"percentage":26.23}
+{"name":"Android - Accessibility features - 2+","feature_key":"accessibility_features","property_key":"2+","platform":"android","amount":2133906,"percentage":26.23}

--- a/src/data/generated/data-features/android-accessibility_is_accessibility_manager_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_accessibility_manager_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is accessibility manager enabled - False","feature_key":"accessibility_is_accessibility_manager_enabled","property_key":"false","platform":"android","amount":1759867,"percentage":23.27}
+{"name":"Android - Accessibility is accessibility manager enabled - False","feature_key":"accessibility_is_accessibility_manager_enabled","property_key":"false","platform":"android","amount":1759774,"percentage":23.26}

--- a/src/data/generated/data-features/android-accessibility_is_accessibility_manager_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_accessibility_manager_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is accessibility manager enabled - False","feature_key":"accessibility_is_accessibility_manager_enabled","property_key":"false","platform":"android","amount":1759490,"percentage":23.21}
+{"name":"Android - Accessibility is accessibility manager enabled - False","feature_key":"accessibility_is_accessibility_manager_enabled","property_key":"false","platform":"android","amount":1759394,"percentage":23.19}

--- a/src/data/generated/data-features/android-accessibility_is_accessibility_manager_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_accessibility_manager_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is accessibility manager enabled - False","feature_key":"accessibility_is_accessibility_manager_enabled","property_key":"false","platform":"android","amount":1759774,"percentage":23.26}
+{"name":"Android - Accessibility is accessibility manager enabled - False","feature_key":"accessibility_is_accessibility_manager_enabled","property_key":"false","platform":"android","amount":1759597,"percentage":23.23}

--- a/src/data/generated/data-features/android-accessibility_is_accessibility_manager_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_accessibility_manager_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is accessibility manager enabled - False","feature_key":"accessibility_is_accessibility_manager_enabled","property_key":"false","platform":"android","amount":1759597,"percentage":23.23}
+{"name":"Android - Accessibility is accessibility manager enabled - False","feature_key":"accessibility_is_accessibility_manager_enabled","property_key":"false","platform":"android","amount":1759490,"percentage":23.21}

--- a/src/data/generated/data-features/android-accessibility_is_accessibility_manager_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_accessibility_manager_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is accessibility manager enabled - True","feature_key":"accessibility_is_accessibility_manager_enabled","property_key":"true","platform":"android","amount":252258,"percentage":3.12}
+{"name":"Android - Accessibility is accessibility manager enabled - True","feature_key":"accessibility_is_accessibility_manager_enabled","property_key":"true","platform":"android","amount":252234,"percentage":3.12}

--- a/src/data/generated/data-features/android-accessibility_is_accessibility_manager_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_accessibility_manager_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is accessibility manager enabled - True","feature_key":"accessibility_is_accessibility_manager_enabled","property_key":"true","platform":"android","amount":252264,"percentage":3.12}
+{"name":"Android - Accessibility is accessibility manager enabled - True","feature_key":"accessibility_is_accessibility_manager_enabled","property_key":"true","platform":"android","amount":252258,"percentage":3.12}

--- a/src/data/generated/data-features/android-accessibility_is_accessibility_manager_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_accessibility_manager_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is accessibility manager enabled - True","feature_key":"accessibility_is_accessibility_manager_enabled","property_key":"true","platform":"android","amount":252216,"percentage":3.12}
+{"name":"Android - Accessibility is accessibility manager enabled - True","feature_key":"accessibility_is_accessibility_manager_enabled","property_key":"true","platform":"android","amount":252201,"percentage":3.12}

--- a/src/data/generated/data-features/android-accessibility_is_accessibility_manager_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_accessibility_manager_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is accessibility manager enabled - True","feature_key":"accessibility_is_accessibility_manager_enabled","property_key":"true","platform":"android","amount":252234,"percentage":3.12}
+{"name":"Android - Accessibility is accessibility manager enabled - True","feature_key":"accessibility_is_accessibility_manager_enabled","property_key":"true","platform":"android","amount":252216,"percentage":3.12}

--- a/src/data/generated/data-features/android-accessibility_is_animation_disabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_animation_disabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is animation disabled - False","feature_key":"accessibility_is_animation_disabled","property_key":"false","platform":"android","amount":5769201,"percentage":72.53}
+{"name":"Android - Accessibility is animation disabled - False","feature_key":"accessibility_is_animation_disabled","property_key":"false","platform":"android","amount":5776807,"percentage":72.56}

--- a/src/data/generated/data-features/android-accessibility_is_animation_disabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_animation_disabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is animation disabled - False","feature_key":"accessibility_is_animation_disabled","property_key":"false","platform":"android","amount":5761554,"percentage":72.5}
+{"name":"Android - Accessibility is animation disabled - False","feature_key":"accessibility_is_animation_disabled","property_key":"false","platform":"android","amount":5769201,"percentage":72.53}

--- a/src/data/generated/data-features/android-accessibility_is_animation_disabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_animation_disabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is animation disabled - False","feature_key":"accessibility_is_animation_disabled","property_key":"false","platform":"android","amount":5757030,"percentage":72.49}
+{"name":"Android - Accessibility is animation disabled - False","feature_key":"accessibility_is_animation_disabled","property_key":"false","platform":"android","amount":5761554,"percentage":72.5}

--- a/src/data/generated/data-features/android-accessibility_is_animation_disabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_animation_disabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is animation disabled - False","feature_key":"accessibility_is_animation_disabled","property_key":"false","platform":"android","amount":5776807,"percentage":72.56}
+{"name":"Android - Accessibility is animation disabled - False","feature_key":"accessibility_is_animation_disabled","property_key":"false","platform":"android","amount":5784497,"percentage":72.58}

--- a/src/data/generated/data-features/android-accessibility_is_animation_disabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_animation_disabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is animation disabled - True","feature_key":"accessibility_is_animation_disabled","property_key":"true","platform":"android","amount":91383,"percentage":1.11}
+{"name":"Android - Accessibility is animation disabled - True","feature_key":"accessibility_is_animation_disabled","property_key":"true","platform":"android","amount":91622,"percentage":1.11}

--- a/src/data/generated/data-features/android-accessibility_is_animation_disabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_animation_disabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is animation disabled - True","feature_key":"accessibility_is_animation_disabled","property_key":"true","platform":"android","amount":91622,"percentage":1.11}
+{"name":"Android - Accessibility is animation disabled - True","feature_key":"accessibility_is_animation_disabled","property_key":"true","platform":"android","amount":91788,"percentage":1.11}

--- a/src/data/generated/data-features/android-accessibility_is_animation_disabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_animation_disabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is animation disabled - True","feature_key":"accessibility_is_animation_disabled","property_key":"true","platform":"android","amount":91788,"percentage":1.11}
+{"name":"Android - Accessibility is animation disabled - True","feature_key":"accessibility_is_animation_disabled","property_key":"true","platform":"android","amount":91957,"percentage":1.11}

--- a/src/data/generated/data-features/android-accessibility_is_animation_disabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_animation_disabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is animation disabled - True","feature_key":"accessibility_is_animation_disabled","property_key":"true","platform":"android","amount":91280,"percentage":1.11}
+{"name":"Android - Accessibility is animation disabled - True","feature_key":"accessibility_is_animation_disabled","property_key":"true","platform":"android","amount":91383,"percentage":1.11}

--- a/src/data/generated/data-features/android-accessibility_is_braille_back_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_braille_back_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is braille back enabled - False","feature_key":"accessibility_is_braille_back_enabled","property_key":"false","platform":"android","amount":7864958,"percentage":100}
+{"name":"Android - Accessibility is braille back enabled - False","feature_key":"accessibility_is_braille_back_enabled","property_key":"false","platform":"android","amount":7872643,"percentage":100}

--- a/src/data/generated/data-features/android-accessibility_is_braille_back_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_braille_back_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is braille back enabled - False","feature_key":"accessibility_is_braille_back_enabled","property_key":"false","platform":"android","amount":7860430,"percentage":100}
+{"name":"Android - Accessibility is braille back enabled - False","feature_key":"accessibility_is_braille_back_enabled","property_key":"false","platform":"android","amount":7864958,"percentage":100}

--- a/src/data/generated/data-features/android-accessibility_is_braille_back_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_braille_back_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is braille back enabled - False","feature_key":"accessibility_is_braille_back_enabled","property_key":"false","platform":"android","amount":7872643,"percentage":100}
+{"name":"Android - Accessibility is braille back enabled - False","feature_key":"accessibility_is_braille_back_enabled","property_key":"false","platform":"android","amount":7880290,"percentage":100}

--- a/src/data/generated/data-features/android-accessibility_is_braille_back_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_braille_back_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is braille back enabled - False","feature_key":"accessibility_is_braille_back_enabled","property_key":"false","platform":"android","amount":7880290,"percentage":100}
+{"name":"Android - Accessibility is braille back enabled - False","feature_key":"accessibility_is_braille_back_enabled","property_key":"false","platform":"android","amount":7888038,"percentage":100}

--- a/src/data/generated/data-features/android-accessibility_is_closed_captioning_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_closed_captioning_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is closed captioning enabled - False","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"false","platform":"android","amount":7486556,"percentage":95.35}
+{"name":"Android - Accessibility is closed captioning enabled - False","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"false","platform":"android","amount":7493835,"percentage":95.35}

--- a/src/data/generated/data-features/android-accessibility_is_closed_captioning_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_closed_captioning_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is closed captioning enabled - False","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"false","platform":"android","amount":7468051,"percentage":95.36}
+{"name":"Android - Accessibility is closed captioning enabled - False","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"false","platform":"android","amount":7472256,"percentage":95.36}

--- a/src/data/generated/data-features/android-accessibility_is_closed_captioning_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_closed_captioning_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is closed captioning enabled - False","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"false","platform":"android","amount":7472256,"percentage":95.36}
+{"name":"Android - Accessibility is closed captioning enabled - False","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"false","platform":"android","amount":7479358,"percentage":95.35}

--- a/src/data/generated/data-features/android-accessibility_is_closed_captioning_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_closed_captioning_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is closed captioning enabled - False","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"false","platform":"android","amount":7479358,"percentage":95.35}
+{"name":"Android - Accessibility is closed captioning enabled - False","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"false","platform":"android","amount":7486556,"percentage":95.35}

--- a/src/data/generated/data-features/android-accessibility_is_closed_captioning_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_closed_captioning_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is closed captioning enabled - True","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"true","platform":"android","amount":392713,"percentage":4.64}
+{"name":"Android - Accessibility is closed captioning enabled - True","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"true","platform":"android","amount":393296,"percentage":4.64}

--- a/src/data/generated/data-features/android-accessibility_is_closed_captioning_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_closed_captioning_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is closed captioning enabled - True","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"true","platform":"android","amount":392390,"percentage":4.64}
+{"name":"Android - Accessibility is closed captioning enabled - True","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"true","platform":"android","amount":392713,"percentage":4.64}

--- a/src/data/generated/data-features/android-accessibility_is_closed_captioning_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_closed_captioning_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is closed captioning enabled - True","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"true","platform":"android","amount":393745,"percentage":4.64}
+{"name":"Android - Accessibility is closed captioning enabled - True","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"true","platform":"android","amount":394214,"percentage":4.64}

--- a/src/data/generated/data-features/android-accessibility_is_closed_captioning_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_closed_captioning_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is closed captioning enabled - True","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"true","platform":"android","amount":393296,"percentage":4.64}
+{"name":"Android - Accessibility is closed captioning enabled - True","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"true","platform":"android","amount":393745,"percentage":4.64}

--- a/src/data/generated/data-features/android-accessibility_is_color_blind_mode_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_color_blind_mode_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is color blind mode enabled - False","feature_key":"accessibility_is_color_blind_mode_enabled","property_key":"false","platform":"android","amount":7850791,"percentage":99.73}
+{"name":"Android - Accessibility is color blind mode enabled - False","feature_key":"accessibility_is_color_blind_mode_enabled","property_key":"false","platform":"android","amount":7858420,"percentage":99.73}

--- a/src/data/generated/data-features/android-accessibility_is_color_blind_mode_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_color_blind_mode_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is color blind mode enabled - False","feature_key":"accessibility_is_color_blind_mode_enabled","property_key":"false","platform":"android","amount":7858420,"percentage":99.73}
+{"name":"Android - Accessibility is color blind mode enabled - False","feature_key":"accessibility_is_color_blind_mode_enabled","property_key":"false","platform":"android","amount":7866148,"percentage":99.73}

--- a/src/data/generated/data-features/android-accessibility_is_color_blind_mode_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_color_blind_mode_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is color blind mode enabled - False","feature_key":"accessibility_is_color_blind_mode_enabled","property_key":"false","platform":"android","amount":7843136,"percentage":99.73}
+{"name":"Android - Accessibility is color blind mode enabled - False","feature_key":"accessibility_is_color_blind_mode_enabled","property_key":"false","platform":"android","amount":7850791,"percentage":99.73}

--- a/src/data/generated/data-features/android-accessibility_is_color_blind_mode_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_color_blind_mode_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is color blind mode enabled - False","feature_key":"accessibility_is_color_blind_mode_enabled","property_key":"false","platform":"android","amount":7838616,"percentage":99.73}
+{"name":"Android - Accessibility is color blind mode enabled - False","feature_key":"accessibility_is_color_blind_mode_enabled","property_key":"false","platform":"android","amount":7843136,"percentage":99.73}

--- a/src/data/generated/data-features/android-accessibility_is_color_blind_mode_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_color_blind_mode_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is color blind mode enabled - True","feature_key":"accessibility_is_color_blind_mode_enabled","property_key":"true","platform":"android","amount":21863,"percentage":0.27}
+{"name":"Android - Accessibility is color blind mode enabled - True","feature_key":"accessibility_is_color_blind_mode_enabled","property_key":"true","platform":"android","amount":21881,"percentage":0.27}

--- a/src/data/generated/data-features/android-accessibility_is_color_blind_mode_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_color_blind_mode_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is color blind mode enabled - True","feature_key":"accessibility_is_color_blind_mode_enabled","property_key":"true","platform":"android","amount":21825,"percentage":0.27}
+{"name":"Android - Accessibility is color blind mode enabled - True","feature_key":"accessibility_is_color_blind_mode_enabled","property_key":"true","platform":"android","amount":21833,"percentage":0.27}

--- a/src/data/generated/data-features/android-accessibility_is_color_blind_mode_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_color_blind_mode_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is color blind mode enabled - True","feature_key":"accessibility_is_color_blind_mode_enabled","property_key":"true","platform":"android","amount":21881,"percentage":0.27}
+{"name":"Android - Accessibility is color blind mode enabled - True","feature_key":"accessibility_is_color_blind_mode_enabled","property_key":"true","platform":"android","amount":21901,"percentage":0.27}

--- a/src/data/generated/data-features/android-accessibility_is_color_blind_mode_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_color_blind_mode_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is color blind mode enabled - True","feature_key":"accessibility_is_color_blind_mode_enabled","property_key":"true","platform":"android","amount":21833,"percentage":0.27}
+{"name":"Android - Accessibility is color blind mode enabled - True","feature_key":"accessibility_is_color_blind_mode_enabled","property_key":"true","platform":"android","amount":21863,"percentage":0.27}

--- a/src/data/generated/data-features/android-accessibility_is_color_inversion_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_color_inversion_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is color inversion enabled - False","feature_key":"accessibility_is_color_inversion_enabled","property_key":"false","platform":"android","amount":7872195,"percentage":100}
+{"name":"Android - Accessibility is color inversion enabled - False","feature_key":"accessibility_is_color_inversion_enabled","property_key":"false","platform":"android","amount":7879841,"percentage":100}

--- a/src/data/generated/data-features/android-accessibility_is_color_inversion_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_color_inversion_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is color inversion enabled - False","feature_key":"accessibility_is_color_inversion_enabled","property_key":"false","platform":"android","amount":7879841,"percentage":100}
+{"name":"Android - Accessibility is color inversion enabled - False","feature_key":"accessibility_is_color_inversion_enabled","property_key":"false","platform":"android","amount":7887590,"percentage":100}

--- a/src/data/generated/data-features/android-accessibility_is_color_inversion_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_color_inversion_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is color inversion enabled - False","feature_key":"accessibility_is_color_inversion_enabled","property_key":"false","platform":"android","amount":7864505,"percentage":100}
+{"name":"Android - Accessibility is color inversion enabled - False","feature_key":"accessibility_is_color_inversion_enabled","property_key":"false","platform":"android","amount":7872195,"percentage":100}

--- a/src/data/generated/data-features/android-accessibility_is_color_inversion_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_color_inversion_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is color inversion enabled - False","feature_key":"accessibility_is_color_inversion_enabled","property_key":"false","platform":"android","amount":7859977,"percentage":100}
+{"name":"Android - Accessibility is color inversion enabled - False","feature_key":"accessibility_is_color_inversion_enabled","property_key":"false","platform":"android","amount":7864505,"percentage":100}

--- a/src/data/generated/data-features/android-accessibility_is_color_inversion_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_color_inversion_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is color inversion enabled - True","feature_key":"accessibility_is_color_inversion_enabled","property_key":"true","platform":"android","amount":464,"percentage":0.01}
+{"name":"Android - Accessibility is color inversion enabled - True","feature_key":"accessibility_is_color_inversion_enabled","property_key":"true","platform":"android","amount":459,"percentage":0.01}

--- a/src/data/generated/data-features/android-accessibility_is_color_inversion_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_color_inversion_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is color inversion enabled - True","feature_key":"accessibility_is_color_inversion_enabled","property_key":"true","platform":"android","amount":459,"percentage":0.01}
+{"name":"Android - Accessibility is color inversion enabled - True","feature_key":"accessibility_is_color_inversion_enabled","property_key":"true","platform":"android","amount":460,"percentage":0.01}

--- a/src/data/generated/data-features/android-accessibility_is_color_inversion_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_color_inversion_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is color inversion enabled - True","feature_key":"accessibility_is_color_inversion_enabled","property_key":"true","platform":"android","amount":460,"percentage":0.01}
+{"name":"Android - Accessibility is color inversion enabled - True","feature_key":"accessibility_is_color_inversion_enabled","property_key":"true","platform":"android","amount":459,"percentage":0.01}

--- a/src/data/generated/data-features/android-accessibility_is_high_text_contrast_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_high_text_contrast_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is high text contrast enabled - False","feature_key":"accessibility_is_high_text_contrast_enabled","property_key":"false","platform":"android","amount":5728165,"percentage":72.02}
+{"name":"Android - Accessibility is high text contrast enabled - False","feature_key":"accessibility_is_high_text_contrast_enabled","property_key":"false","platform":"android","amount":5735722,"percentage":72.04}

--- a/src/data/generated/data-features/android-accessibility_is_high_text_contrast_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_high_text_contrast_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is high text contrast enabled - False","feature_key":"accessibility_is_high_text_contrast_enabled","property_key":"false","platform":"android","amount":5716067,"percentage":71.98}
+{"name":"Android - Accessibility is high text contrast enabled - False","feature_key":"accessibility_is_high_text_contrast_enabled","property_key":"false","platform":"android","amount":5720560,"percentage":72}

--- a/src/data/generated/data-features/android-accessibility_is_high_text_contrast_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_high_text_contrast_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is high text contrast enabled - False","feature_key":"accessibility_is_high_text_contrast_enabled","property_key":"false","platform":"android","amount":5720560,"percentage":72}
+{"name":"Android - Accessibility is high text contrast enabled - False","feature_key":"accessibility_is_high_text_contrast_enabled","property_key":"false","platform":"android","amount":5728165,"percentage":72.02}

--- a/src/data/generated/data-features/android-accessibility_is_high_text_contrast_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_high_text_contrast_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is high text contrast enabled - False","feature_key":"accessibility_is_high_text_contrast_enabled","property_key":"false","platform":"android","amount":5735722,"percentage":72.04}
+{"name":"Android - Accessibility is high text contrast enabled - False","feature_key":"accessibility_is_high_text_contrast_enabled","property_key":"false","platform":"android","amount":5743349,"percentage":72.07}

--- a/src/data/generated/data-features/android-accessibility_is_high_text_contrast_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_high_text_contrast_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is high text contrast enabled - True","feature_key":"accessibility_is_high_text_contrast_enabled","property_key":"true","platform":"android","amount":132377,"percentage":1.62}
+{"name":"Android - Accessibility is high text contrast enabled - True","feature_key":"accessibility_is_high_text_contrast_enabled","property_key":"true","platform":"android","amount":132658,"percentage":1.62}

--- a/src/data/generated/data-features/android-accessibility_is_high_text_contrast_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_high_text_contrast_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is high text contrast enabled - True","feature_key":"accessibility_is_high_text_contrast_enabled","property_key":"true","platform":"android","amount":132873,"percentage":1.63}
+{"name":"Android - Accessibility is high text contrast enabled - True","feature_key":"accessibility_is_high_text_contrast_enabled","property_key":"true","platform":"android","amount":133105,"percentage":1.64}

--- a/src/data/generated/data-features/android-accessibility_is_high_text_contrast_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_high_text_contrast_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is high text contrast enabled - True","feature_key":"accessibility_is_high_text_contrast_enabled","property_key":"true","platform":"android","amount":132243,"percentage":1.62}
+{"name":"Android - Accessibility is high text contrast enabled - True","feature_key":"accessibility_is_high_text_contrast_enabled","property_key":"true","platform":"android","amount":132377,"percentage":1.62}

--- a/src/data/generated/data-features/android-accessibility_is_high_text_contrast_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_high_text_contrast_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is high text contrast enabled - True","feature_key":"accessibility_is_high_text_contrast_enabled","property_key":"true","platform":"android","amount":132658,"percentage":1.62}
+{"name":"Android - Accessibility is high text contrast enabled - True","feature_key":"accessibility_is_high_text_contrast_enabled","property_key":"true","platform":"android","amount":132873,"percentage":1.63}

--- a/src/data/generated/data-features/android-accessibility_is_magnification_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_magnification_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is magnification enabled - False","feature_key":"accessibility_is_magnification_enabled","property_key":"false","platform":"android","amount":1322012,"percentage":16.04}
+{"name":"Android - Accessibility is magnification enabled - False","feature_key":"accessibility_is_magnification_enabled","property_key":"false","platform":"android","amount":1323426,"percentage":16.04}

--- a/src/data/generated/data-features/android-accessibility_is_magnification_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_magnification_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is magnification enabled - False","feature_key":"accessibility_is_magnification_enabled","property_key":"false","platform":"android","amount":1320061,"percentage":16.02}
+{"name":"Android - Accessibility is magnification enabled - False","feature_key":"accessibility_is_magnification_enabled","property_key":"false","platform":"android","amount":1322012,"percentage":16.04}

--- a/src/data/generated/data-features/android-accessibility_is_magnification_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_magnification_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is magnification enabled - False","feature_key":"accessibility_is_magnification_enabled","property_key":"false","platform":"android","amount":1318997,"percentage":16.02}
+{"name":"Android - Accessibility is magnification enabled - False","feature_key":"accessibility_is_magnification_enabled","property_key":"false","platform":"android","amount":1320061,"percentage":16.02}

--- a/src/data/generated/data-features/android-accessibility_is_magnification_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_magnification_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is magnification enabled - False","feature_key":"accessibility_is_magnification_enabled","property_key":"false","platform":"android","amount":1323426,"percentage":16.04}
+{"name":"Android - Accessibility is magnification enabled - False","feature_key":"accessibility_is_magnification_enabled","property_key":"false","platform":"android","amount":1324824,"percentage":16.04}

--- a/src/data/generated/data-features/android-accessibility_is_magnification_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_magnification_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is magnification enabled - True","feature_key":"accessibility_is_magnification_enabled","property_key":"true","platform":"android","amount":47459,"percentage":0.57}
+{"name":"Android - Accessibility is magnification enabled - True","feature_key":"accessibility_is_magnification_enabled","property_key":"true","platform":"android","amount":47515,"percentage":0.57}

--- a/src/data/generated/data-features/android-accessibility_is_magnification_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_magnification_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is magnification enabled - True","feature_key":"accessibility_is_magnification_enabled","property_key":"true","platform":"android","amount":47576,"percentage":0.57}
+{"name":"Android - Accessibility is magnification enabled - True","feature_key":"accessibility_is_magnification_enabled","property_key":"true","platform":"android","amount":47655,"percentage":0.57}

--- a/src/data/generated/data-features/android-accessibility_is_magnification_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_magnification_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is magnification enabled - True","feature_key":"accessibility_is_magnification_enabled","property_key":"true","platform":"android","amount":47408,"percentage":0.57}
+{"name":"Android - Accessibility is magnification enabled - True","feature_key":"accessibility_is_magnification_enabled","property_key":"true","platform":"android","amount":47459,"percentage":0.57}

--- a/src/data/generated/data-features/android-accessibility_is_magnification_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_magnification_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is magnification enabled - True","feature_key":"accessibility_is_magnification_enabled","property_key":"true","platform":"android","amount":47515,"percentage":0.57}
+{"name":"Android - Accessibility is magnification enabled - True","feature_key":"accessibility_is_magnification_enabled","property_key":"true","platform":"android","amount":47576,"percentage":0.57}

--- a/src/data/generated/data-features/android-accessibility_is_samsung_talk_back_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_samsung_talk_back_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is samsung talk back enabled - False","feature_key":"accessibility_is_samsung_talk_back_enabled","property_key":"false","platform":"android","amount":7860397,"percentage":100}
+{"name":"Android - Accessibility is samsung talk back enabled - False","feature_key":"accessibility_is_samsung_talk_back_enabled","property_key":"false","platform":"android","amount":7864925,"percentage":100}

--- a/src/data/generated/data-features/android-accessibility_is_samsung_talk_back_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_samsung_talk_back_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is samsung talk back enabled - False","feature_key":"accessibility_is_samsung_talk_back_enabled","property_key":"false","platform":"android","amount":7880257,"percentage":100}
+{"name":"Android - Accessibility is samsung talk back enabled - False","feature_key":"accessibility_is_samsung_talk_back_enabled","property_key":"false","platform":"android","amount":7888005,"percentage":100}

--- a/src/data/generated/data-features/android-accessibility_is_samsung_talk_back_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_samsung_talk_back_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is samsung talk back enabled - False","feature_key":"accessibility_is_samsung_talk_back_enabled","property_key":"false","platform":"android","amount":7872610,"percentage":100}
+{"name":"Android - Accessibility is samsung talk back enabled - False","feature_key":"accessibility_is_samsung_talk_back_enabled","property_key":"false","platform":"android","amount":7880257,"percentage":100}

--- a/src/data/generated/data-features/android-accessibility_is_samsung_talk_back_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_samsung_talk_back_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is samsung talk back enabled - False","feature_key":"accessibility_is_samsung_talk_back_enabled","property_key":"false","platform":"android","amount":7864925,"percentage":100}
+{"name":"Android - Accessibility is samsung talk back enabled - False","feature_key":"accessibility_is_samsung_talk_back_enabled","property_key":"false","platform":"android","amount":7872610,"percentage":100}

--- a/src/data/generated/data-features/android-accessibility_is_select_to_speak_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_select_to_speak_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is select to speak enabled - False","feature_key":"accessibility_is_select_to_speak_enabled","property_key":"false","platform":"android","amount":7851807,"percentage":99.89}
+{"name":"Android - Accessibility is select to speak enabled - False","feature_key":"accessibility_is_select_to_speak_enabled","property_key":"false","platform":"android","amount":7856335,"percentage":99.89}

--- a/src/data/generated/data-features/android-accessibility_is_select_to_speak_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_select_to_speak_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is select to speak enabled - False","feature_key":"accessibility_is_select_to_speak_enabled","property_key":"false","platform":"android","amount":7856335,"percentage":99.89}
+{"name":"Android - Accessibility is select to speak enabled - False","feature_key":"accessibility_is_select_to_speak_enabled","property_key":"false","platform":"android","amount":7864009,"percentage":99.89}

--- a/src/data/generated/data-features/android-accessibility_is_select_to_speak_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_select_to_speak_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is select to speak enabled - False","feature_key":"accessibility_is_select_to_speak_enabled","property_key":"false","platform":"android","amount":7871658,"percentage":99.89}
+{"name":"Android - Accessibility is select to speak enabled - False","feature_key":"accessibility_is_select_to_speak_enabled","property_key":"false","platform":"android","amount":7879391,"percentage":99.89}

--- a/src/data/generated/data-features/android-accessibility_is_select_to_speak_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_select_to_speak_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is select to speak enabled - False","feature_key":"accessibility_is_select_to_speak_enabled","property_key":"false","platform":"android","amount":7864009,"percentage":99.89}
+{"name":"Android - Accessibility is select to speak enabled - False","feature_key":"accessibility_is_select_to_speak_enabled","property_key":"false","platform":"android","amount":7871658,"percentage":99.89}

--- a/src/data/generated/data-features/android-accessibility_is_select_to_speak_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_select_to_speak_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is select to speak enabled - True","feature_key":"accessibility_is_select_to_speak_enabled","property_key":"true","platform":"android","amount":8643,"percentage":0.1}
+{"name":"Android - Accessibility is select to speak enabled - True","feature_key":"accessibility_is_select_to_speak_enabled","property_key":"true","platform":"android","amount":8658,"percentage":0.1}

--- a/src/data/generated/data-features/android-accessibility_is_select_to_speak_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_select_to_speak_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is select to speak enabled - True","feature_key":"accessibility_is_select_to_speak_enabled","property_key":"true","platform":"android","amount":8634,"percentage":0.1}
+{"name":"Android - Accessibility is select to speak enabled - True","feature_key":"accessibility_is_select_to_speak_enabled","property_key":"true","platform":"android","amount":8645,"percentage":0.1}

--- a/src/data/generated/data-features/android-accessibility_is_select_to_speak_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_select_to_speak_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is select to speak enabled - True","feature_key":"accessibility_is_select_to_speak_enabled","property_key":"true","platform":"android","amount":8645,"percentage":0.1}
+{"name":"Android - Accessibility is select to speak enabled - True","feature_key":"accessibility_is_select_to_speak_enabled","property_key":"true","platform":"android","amount":8643,"percentage":0.1}

--- a/src/data/generated/data-features/android-accessibility_is_switch_access_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_switch_access_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is switch access enabled - False","feature_key":"accessibility_is_switch_access_enabled","property_key":"false","platform":"android","amount":7874069,"percentage":99.92}
+{"name":"Android - Accessibility is switch access enabled - False","feature_key":"accessibility_is_switch_access_enabled","property_key":"false","platform":"android","amount":7881815,"percentage":99.92}

--- a/src/data/generated/data-features/android-accessibility_is_switch_access_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_switch_access_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is switch access enabled - False","feature_key":"accessibility_is_switch_access_enabled","property_key":"false","platform":"android","amount":7858751,"percentage":99.92}
+{"name":"Android - Accessibility is switch access enabled - False","feature_key":"accessibility_is_switch_access_enabled","property_key":"false","platform":"android","amount":7866429,"percentage":99.92}

--- a/src/data/generated/data-features/android-accessibility_is_switch_access_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_switch_access_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is switch access enabled - False","feature_key":"accessibility_is_switch_access_enabled","property_key":"false","platform":"android","amount":7866429,"percentage":99.92}
+{"name":"Android - Accessibility is switch access enabled - False","feature_key":"accessibility_is_switch_access_enabled","property_key":"false","platform":"android","amount":7874069,"percentage":99.92}

--- a/src/data/generated/data-features/android-accessibility_is_switch_access_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_switch_access_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is switch access enabled - False","feature_key":"accessibility_is_switch_access_enabled","property_key":"false","platform":"android","amount":7854231,"percentage":99.92}
+{"name":"Android - Accessibility is switch access enabled - False","feature_key":"accessibility_is_switch_access_enabled","property_key":"false","platform":"android","amount":7858751,"percentage":99.92}

--- a/src/data/generated/data-features/android-accessibility_is_switch_access_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_switch_access_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is switch access enabled - True","feature_key":"accessibility_is_switch_access_enabled","property_key":"true","platform":"android","amount":6218,"percentage":0.07}
+{"name":"Android - Accessibility is switch access enabled - True","feature_key":"accessibility_is_switch_access_enabled","property_key":"true","platform":"android","amount":6225,"percentage":0.07}

--- a/src/data/generated/data-features/android-accessibility_is_switch_access_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_switch_access_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is switch access enabled - True","feature_key":"accessibility_is_switch_access_enabled","property_key":"true","platform":"android","amount":6232,"percentage":0.07}
+{"name":"Android - Accessibility is switch access enabled - True","feature_key":"accessibility_is_switch_access_enabled","property_key":"true","platform":"android","amount":6234,"percentage":0.07}

--- a/src/data/generated/data-features/android-accessibility_is_switch_access_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_switch_access_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is switch access enabled - True","feature_key":"accessibility_is_switch_access_enabled","property_key":"true","platform":"android","amount":6225,"percentage":0.07}
+{"name":"Android - Accessibility is switch access enabled - True","feature_key":"accessibility_is_switch_access_enabled","property_key":"true","platform":"android","amount":6232,"percentage":0.07}

--- a/src/data/generated/data-features/android-accessibility_is_switch_access_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_switch_access_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is switch access enabled - True","feature_key":"accessibility_is_switch_access_enabled","property_key":"true","platform":"android","amount":6210,"percentage":0.07}
+{"name":"Android - Accessibility is switch access enabled - True","feature_key":"accessibility_is_switch_access_enabled","property_key":"true","platform":"android","amount":6218,"percentage":0.07}

--- a/src/data/generated/data-features/android-accessibility_is_talk_back_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_talk_back_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is talk back enabled - False","feature_key":"accessibility_is_talk_back_enabled","property_key":"false","platform":"android","amount":7859851,"percentage":100}
+{"name":"Android - Accessibility is talk back enabled - False","feature_key":"accessibility_is_talk_back_enabled","property_key":"false","platform":"android","amount":7864381,"percentage":100}

--- a/src/data/generated/data-features/android-accessibility_is_talk_back_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_talk_back_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is talk back enabled - False","feature_key":"accessibility_is_talk_back_enabled","property_key":"false","platform":"android","amount":7879714,"percentage":100}
+{"name":"Android - Accessibility is talk back enabled - False","feature_key":"accessibility_is_talk_back_enabled","property_key":"false","platform":"android","amount":7887463,"percentage":100}

--- a/src/data/generated/data-features/android-accessibility_is_talk_back_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_talk_back_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is talk back enabled - False","feature_key":"accessibility_is_talk_back_enabled","property_key":"false","platform":"android","amount":7864381,"percentage":100}
+{"name":"Android - Accessibility is talk back enabled - False","feature_key":"accessibility_is_talk_back_enabled","property_key":"false","platform":"android","amount":7872068,"percentage":100}

--- a/src/data/generated/data-features/android-accessibility_is_talk_back_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_talk_back_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is talk back enabled - False","feature_key":"accessibility_is_talk_back_enabled","property_key":"false","platform":"android","amount":7872068,"percentage":100}
+{"name":"Android - Accessibility is talk back enabled - False","feature_key":"accessibility_is_talk_back_enabled","property_key":"false","platform":"android","amount":7879714,"percentage":100}

--- a/src/data/generated/data-features/android-accessibility_is_talk_back_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_talk_back_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is talk back enabled - True","feature_key":"accessibility_is_talk_back_enabled","property_key":"true","platform":"android","amount":586,"percentage":0.01}
+{"name":"Android - Accessibility is talk back enabled - True","feature_key":"accessibility_is_talk_back_enabled","property_key":"true","platform":"android","amount":587,"percentage":0.01}

--- a/src/data/generated/data-features/android-accessibility_is_talk_back_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_talk_back_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is talk back enabled - True","feature_key":"accessibility_is_talk_back_enabled","property_key":"true","platform":"android","amount":590,"percentage":0.01}
+{"name":"Android - Accessibility is talk back enabled - True","feature_key":"accessibility_is_talk_back_enabled","property_key":"true","platform":"android","amount":588,"percentage":0.01}

--- a/src/data/generated/data-features/android-accessibility_is_talk_back_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_talk_back_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is talk back enabled - True","feature_key":"accessibility_is_talk_back_enabled","property_key":"true","platform":"android","amount":588,"percentage":0.01}
+{"name":"Android - Accessibility is talk back enabled - True","feature_key":"accessibility_is_talk_back_enabled","property_key":"true","platform":"android","amount":586,"percentage":0.01}

--- a/src/data/generated/data-features/android-accessibility_is_talk_back_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_talk_back_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is talk back enabled - True","feature_key":"accessibility_is_talk_back_enabled","property_key":"true","platform":"android","amount":587,"percentage":0.01}
+{"name":"Android - Accessibility is talk back enabled - True","feature_key":"accessibility_is_talk_back_enabled","property_key":"true","platform":"android","amount":586,"percentage":0.01}

--- a/src/data/generated/data-features/android-accessibility_is_touch_exploration_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_touch_exploration_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is touch exploration enabled - False","feature_key":"accessibility_is_touch_exploration_enabled","property_key":"false","platform":"android","amount":7859855,"percentage":100}
+{"name":"Android - Accessibility is touch exploration enabled - False","feature_key":"accessibility_is_touch_exploration_enabled","property_key":"false","platform":"android","amount":7864385,"percentage":100}

--- a/src/data/generated/data-features/android-accessibility_is_touch_exploration_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_touch_exploration_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is touch exploration enabled - False","feature_key":"accessibility_is_touch_exploration_enabled","property_key":"false","platform":"android","amount":7879718,"percentage":100}
+{"name":"Android - Accessibility is touch exploration enabled - False","feature_key":"accessibility_is_touch_exploration_enabled","property_key":"false","platform":"android","amount":7887467,"percentage":100}

--- a/src/data/generated/data-features/android-accessibility_is_touch_exploration_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_touch_exploration_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is touch exploration enabled - False","feature_key":"accessibility_is_touch_exploration_enabled","property_key":"false","platform":"android","amount":7864385,"percentage":100}
+{"name":"Android - Accessibility is touch exploration enabled - False","feature_key":"accessibility_is_touch_exploration_enabled","property_key":"false","platform":"android","amount":7872072,"percentage":100}

--- a/src/data/generated/data-features/android-accessibility_is_touch_exploration_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_touch_exploration_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is touch exploration enabled - False","feature_key":"accessibility_is_touch_exploration_enabled","property_key":"false","platform":"android","amount":7872072,"percentage":100}
+{"name":"Android - Accessibility is touch exploration enabled - False","feature_key":"accessibility_is_touch_exploration_enabled","property_key":"false","platform":"android","amount":7879718,"percentage":100}

--- a/src/data/generated/data-features/android-accessibility_is_touch_exploration_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_touch_exploration_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is touch exploration enabled - True","feature_key":"accessibility_is_touch_exploration_enabled","property_key":"true","platform":"android","amount":586,"percentage":0.01}
+{"name":"Android - Accessibility is touch exploration enabled - True","feature_key":"accessibility_is_touch_exploration_enabled","property_key":"true","platform":"android","amount":584,"percentage":0.01}

--- a/src/data/generated/data-features/android-accessibility_is_touch_exploration_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_touch_exploration_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is touch exploration enabled - True","feature_key":"accessibility_is_touch_exploration_enabled","property_key":"true","platform":"android","amount":584,"percentage":0.01}
+{"name":"Android - Accessibility is touch exploration enabled - True","feature_key":"accessibility_is_touch_exploration_enabled","property_key":"true","platform":"android","amount":582,"percentage":0.01}

--- a/src/data/generated/data-features/android-accessibility_is_touch_exploration_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_touch_exploration_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is touch exploration enabled - True","feature_key":"accessibility_is_touch_exploration_enabled","property_key":"true","platform":"android","amount":583,"percentage":0.01}
+{"name":"Android - Accessibility is touch exploration enabled - True","feature_key":"accessibility_is_touch_exploration_enabled","property_key":"true","platform":"android","amount":582,"percentage":0.01}

--- a/src/data/generated/data-features/android-accessibility_is_touch_exploration_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_touch_exploration_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is touch exploration enabled - True","feature_key":"accessibility_is_touch_exploration_enabled","property_key":"true","platform":"android","amount":582,"percentage":0.01}
+{"name":"Android - Accessibility is touch exploration enabled - True","feature_key":"accessibility_is_touch_exploration_enabled","property_key":"true","platform":"android","amount":583,"percentage":0.01}

--- a/src/data/generated/data-features/android-accessibility_is_voice_access_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_voice_access_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is voice access enabled - False","feature_key":"accessibility_is_voice_access_enabled","property_key":"false","platform":"android","amount":7867962,"percentage":99.94}
+{"name":"Android - Accessibility is voice access enabled - False","feature_key":"accessibility_is_voice_access_enabled","property_key":"false","platform":"android","amount":7875602,"percentage":99.94}

--- a/src/data/generated/data-features/android-accessibility_is_voice_access_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_voice_access_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is voice access enabled - False","feature_key":"accessibility_is_voice_access_enabled","property_key":"false","platform":"android","amount":7855769,"percentage":99.94}
+{"name":"Android - Accessibility is voice access enabled - False","feature_key":"accessibility_is_voice_access_enabled","property_key":"false","platform":"android","amount":7860294,"percentage":99.94}

--- a/src/data/generated/data-features/android-accessibility_is_voice_access_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_voice_access_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is voice access enabled - False","feature_key":"accessibility_is_voice_access_enabled","property_key":"false","platform":"android","amount":7860294,"percentage":99.94}
+{"name":"Android - Accessibility is voice access enabled - False","feature_key":"accessibility_is_voice_access_enabled","property_key":"false","platform":"android","amount":7867962,"percentage":99.94}

--- a/src/data/generated/data-features/android-accessibility_is_voice_access_enabled-false.json
+++ b/src/data/generated/data-features/android-accessibility_is_voice_access_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is voice access enabled - False","feature_key":"accessibility_is_voice_access_enabled","property_key":"false","platform":"android","amount":7875602,"percentage":99.94}
+{"name":"Android - Accessibility is voice access enabled - False","feature_key":"accessibility_is_voice_access_enabled","property_key":"false","platform":"android","amount":7883338,"percentage":99.94}

--- a/src/data/generated/data-features/android-accessibility_is_voice_access_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_voice_access_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is voice access enabled - True","feature_key":"accessibility_is_voice_access_enabled","property_key":"true","platform":"android","amount":4692,"percentage":0.06}
+{"name":"Android - Accessibility is voice access enabled - True","feature_key":"accessibility_is_voice_access_enabled","property_key":"true","platform":"android","amount":4699,"percentage":0.06}

--- a/src/data/generated/data-features/android-accessibility_is_voice_access_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_voice_access_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is voice access enabled - True","feature_key":"accessibility_is_voice_access_enabled","property_key":"true","platform":"android","amount":4675,"percentage":0.06}
+{"name":"Android - Accessibility is voice access enabled - True","feature_key":"accessibility_is_voice_access_enabled","property_key":"true","platform":"android","amount":4692,"percentage":0.06}

--- a/src/data/generated/data-features/android-accessibility_is_voice_access_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_voice_access_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is voice access enabled - True","feature_key":"accessibility_is_voice_access_enabled","property_key":"true","platform":"android","amount":4699,"percentage":0.06}
+{"name":"Android - Accessibility is voice access enabled - True","feature_key":"accessibility_is_voice_access_enabled","property_key":"true","platform":"android","amount":4711,"percentage":0.06}

--- a/src/data/generated/data-features/android-accessibility_is_voice_access_enabled-true.json
+++ b/src/data/generated/data-features/android-accessibility_is_voice_access_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Accessibility is voice access enabled - True","feature_key":"accessibility_is_voice_access_enabled","property_key":"true","platform":"android","amount":4672,"percentage":0.06}
+{"name":"Android - Accessibility is voice access enabled - True","feature_key":"accessibility_is_voice_access_enabled","property_key":"true","platform":"android","amount":4675,"percentage":0.06}

--- a/src/data/generated/data-features/android-default_screen_display_scale-false.json
+++ b/src/data/generated/data-features/android-default_screen_display_scale-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Default screen display scale - False","feature_key":"default_screen_display_scale","property_key":"false","platform":"android","amount":2065767,"percentage":25.95}
+{"name":"Android - Default screen display scale - False","feature_key":"default_screen_display_scale","property_key":"false","platform":"android","amount":2068173,"percentage":25.96}

--- a/src/data/generated/data-features/android-default_screen_display_scale-false.json
+++ b/src/data/generated/data-features/android-default_screen_display_scale-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Default screen display scale - False","feature_key":"default_screen_display_scale","property_key":"false","platform":"android","amount":2064064,"percentage":25.95}
+{"name":"Android - Default screen display scale - False","feature_key":"default_screen_display_scale","property_key":"false","platform":"android","amount":2065767,"percentage":25.95}

--- a/src/data/generated/data-features/android-default_screen_display_scale-false.json
+++ b/src/data/generated/data-features/android-default_screen_display_scale-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Default screen display scale - False","feature_key":"default_screen_display_scale","property_key":"false","platform":"android","amount":2070394,"percentage":25.96}
+{"name":"Android - Default screen display scale - False","feature_key":"default_screen_display_scale","property_key":"false","platform":"android","amount":2072627,"percentage":25.96}

--- a/src/data/generated/data-features/android-default_screen_display_scale-false.json
+++ b/src/data/generated/data-features/android-default_screen_display_scale-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Default screen display scale - False","feature_key":"default_screen_display_scale","property_key":"false","platform":"android","amount":2068173,"percentage":25.96}
+{"name":"Android - Default screen display scale - False","feature_key":"default_screen_display_scale","property_key":"false","platform":"android","amount":2070394,"percentage":25.96}

--- a/src/data/generated/data-features/android-default_screen_display_scale-true.json
+++ b/src/data/generated/data-features/android-default_screen_display_scale-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Default screen display scale - True","feature_key":"default_screen_display_scale","property_key":"true","platform":"android","amount":5772812,"percentage":73.81}
+{"name":"Android - Default screen display scale - True","feature_key":"default_screen_display_scale","property_key":"true","platform":"android","amount":5778064,"percentage":73.81}

--- a/src/data/generated/data-features/android-default_screen_display_scale-true.json
+++ b/src/data/generated/data-features/android-default_screen_display_scale-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Default screen display scale - True","feature_key":"default_screen_display_scale","property_key":"true","platform":"android","amount":5768124,"percentage":73.79}
+{"name":"Android - Default screen display scale - True","feature_key":"default_screen_display_scale","property_key":"true","platform":"android","amount":5772812,"percentage":73.81}

--- a/src/data/generated/data-features/android-default_screen_display_scale-true.json
+++ b/src/data/generated/data-features/android-default_screen_display_scale-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Default screen display scale - True","feature_key":"default_screen_display_scale","property_key":"true","platform":"android","amount":5783466,"percentage":73.8}
+{"name":"Android - Default screen display scale - True","feature_key":"default_screen_display_scale","property_key":"true","platform":"android","amount":5788950,"percentage":73.8}

--- a/src/data/generated/data-features/android-default_screen_display_scale-true.json
+++ b/src/data/generated/data-features/android-default_screen_display_scale-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Default screen display scale - True","feature_key":"default_screen_display_scale","property_key":"true","platform":"android","amount":5778064,"percentage":73.81}
+{"name":"Android - Default screen display scale - True","feature_key":"default_screen_display_scale","property_key":"true","platform":"android","amount":5783466,"percentage":73.8}

--- a/src/data/generated/data-features/android-default_screen_font_scale-false.json
+++ b/src/data/generated/data-features/android-default_screen_font_scale-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Default screen font scale - False","feature_key":"default_screen_font_scale","property_key":"false","platform":"android","amount":2926315,"percentage":37.3}
+{"name":"Android - Default screen font scale - False","feature_key":"default_screen_font_scale","property_key":"false","platform":"android","amount":2929078,"percentage":37.3}

--- a/src/data/generated/data-features/android-default_screen_font_scale-false.json
+++ b/src/data/generated/data-features/android-default_screen_font_scale-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Default screen font scale - False","feature_key":"default_screen_font_scale","property_key":"false","platform":"android","amount":2923288,"percentage":37.3}
+{"name":"Android - Default screen font scale - False","feature_key":"default_screen_font_scale","property_key":"false","platform":"android","amount":2926315,"percentage":37.3}

--- a/src/data/generated/data-features/android-default_screen_font_scale-false.json
+++ b/src/data/generated/data-features/android-default_screen_font_scale-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Default screen font scale - False","feature_key":"default_screen_font_scale","property_key":"false","platform":"android","amount":2921026,"percentage":37.29}
+{"name":"Android - Default screen font scale - False","feature_key":"default_screen_font_scale","property_key":"false","platform":"android","amount":2923288,"percentage":37.3}

--- a/src/data/generated/data-features/android-default_screen_font_scale-false.json
+++ b/src/data/generated/data-features/android-default_screen_font_scale-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Default screen font scale - False","feature_key":"default_screen_font_scale","property_key":"false","platform":"android","amount":2929078,"percentage":37.3}
+{"name":"Android - Default screen font scale - False","feature_key":"default_screen_font_scale","property_key":"false","platform":"android","amount":2932012,"percentage":37.3}

--- a/src/data/generated/data-features/android-default_screen_font_scale-true.json
+++ b/src/data/generated/data-features/android-default_screen_font_scale-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Default screen font scale - True","feature_key":"default_screen_font_scale","property_key":"true","platform":"android","amount":4924782,"percentage":62.47}
+{"name":"Android - Default screen font scale - True","feature_key":"default_screen_font_scale","property_key":"true","platform":"android","amount":4929565,"percentage":62.46}

--- a/src/data/generated/data-features/android-default_screen_font_scale-true.json
+++ b/src/data/generated/data-features/android-default_screen_font_scale-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Default screen font scale - True","feature_key":"default_screen_font_scale","property_key":"true","platform":"android","amount":4911162,"percentage":62.45}
+{"name":"Android - Default screen font scale - True","feature_key":"default_screen_font_scale","property_key":"true","platform":"android","amount":4915291,"percentage":62.47}

--- a/src/data/generated/data-features/android-default_screen_font_scale-true.json
+++ b/src/data/generated/data-features/android-default_screen_font_scale-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Default screen font scale - True","feature_key":"default_screen_font_scale","property_key":"true","platform":"android","amount":4919922,"percentage":62.47}
+{"name":"Android - Default screen font scale - True","feature_key":"default_screen_font_scale","property_key":"true","platform":"android","amount":4924782,"percentage":62.47}

--- a/src/data/generated/data-features/android-default_screen_font_scale-true.json
+++ b/src/data/generated/data-features/android-default_screen_font_scale-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Default screen font scale - True","feature_key":"default_screen_font_scale","property_key":"true","platform":"android","amount":4915291,"percentage":62.47}
+{"name":"Android - Default screen font scale - True","feature_key":"default_screen_font_scale","property_key":"true","platform":"android","amount":4919922,"percentage":62.47}

--- a/src/data/generated/data-features/android-preference_daytime-day.json
+++ b/src/data/generated/data-features/android-preference_daytime-day.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference daytime - Day","feature_key":"preference_daytime","property_key":"day","platform":"android","amount":3490564,"percentage":44.3}
+{"name":"Android - Preference daytime - Day","feature_key":"preference_daytime","property_key":"day","platform":"android","amount":3470419,"percentage":43.97}

--- a/src/data/generated/data-features/android-preference_daytime-day.json
+++ b/src/data/generated/data-features/android-preference_daytime-day.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference daytime - Day","feature_key":"preference_daytime","property_key":"day","platform":"android","amount":3428855,"percentage":43.5}
+{"name":"Android - Preference daytime - Day","feature_key":"preference_daytime","property_key":"day","platform":"android","amount":3419297,"percentage":43.3}

--- a/src/data/generated/data-features/android-preference_daytime-day.json
+++ b/src/data/generated/data-features/android-preference_daytime-day.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference daytime - Day","feature_key":"preference_daytime","property_key":"day","platform":"android","amount":3419297,"percentage":43.3}
+{"name":"Android - Preference daytime - Day","feature_key":"preference_daytime","property_key":"day","platform":"android","amount":3402343,"percentage":42.91}

--- a/src/data/generated/data-features/android-preference_daytime-day.json
+++ b/src/data/generated/data-features/android-preference_daytime-day.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference daytime - Day","feature_key":"preference_daytime","property_key":"day","platform":"android","amount":3470419,"percentage":43.97}
+{"name":"Android - Preference daytime - Day","feature_key":"preference_daytime","property_key":"day","platform":"android","amount":3428855,"percentage":43.5}

--- a/src/data/generated/data-features/android-preference_daytime-night.json
+++ b/src/data/generated/data-features/android-preference_daytime-night.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference daytime - Night","feature_key":"preference_daytime","property_key":"night","platform":"android","amount":1725370,"percentage":21.27}
+{"name":"Android - Preference daytime - Night","feature_key":"preference_daytime","property_key":"night","platform":"android","amount":1746214,"percentage":21.64}

--- a/src/data/generated/data-features/android-preference_daytime-night.json
+++ b/src/data/generated/data-features/android-preference_daytime-night.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference daytime - Night","feature_key":"preference_daytime","property_key":"night","platform":"android","amount":1637988,"percentage":20.32}
+{"name":"Android - Preference daytime - Night","feature_key":"preference_daytime","property_key":"night","platform":"android","amount":1662215,"percentage":20.64}

--- a/src/data/generated/data-features/android-preference_daytime-night.json
+++ b/src/data/generated/data-features/android-preference_daytime-night.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference daytime - Night","feature_key":"preference_daytime","property_key":"night","platform":"android","amount":1713927,"percentage":21.12}
+{"name":"Android - Preference daytime - Night","feature_key":"preference_daytime","property_key":"night","platform":"android","amount":1725370,"percentage":21.27}

--- a/src/data/generated/data-features/android-preference_daytime-night.json
+++ b/src/data/generated/data-features/android-preference_daytime-night.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference daytime - Night","feature_key":"preference_daytime","property_key":"night","platform":"android","amount":1662215,"percentage":20.64}
+{"name":"Android - Preference daytime - Night","feature_key":"preference_daytime","property_key":"night","platform":"android","amount":1713927,"percentage":21.12}

--- a/src/data/generated/data-features/android-preference_daytime-twilight.json
+++ b/src/data/generated/data-features/android-preference_daytime-twilight.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference daytime - Twilight","feature_key":"preference_daytime","property_key":"twilight","platform":"android","amount":1527176,"percentage":18.59}
+{"name":"Android - Preference daytime - Twilight","feature_key":"preference_daytime","property_key":"twilight","platform":"android","amount":1528590,"percentage":18.62}

--- a/src/data/generated/data-features/android-preference_daytime-twilight.json
+++ b/src/data/generated/data-features/android-preference_daytime-twilight.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference daytime - Twilight","feature_key":"preference_daytime","property_key":"twilight","platform":"android","amount":1537229,"percentage":18.73}
+{"name":"Android - Preference daytime - Twilight","feature_key":"preference_daytime","property_key":"twilight","platform":"android","amount":1541164,"percentage":18.75}

--- a/src/data/generated/data-features/android-preference_daytime-twilight.json
+++ b/src/data/generated/data-features/android-preference_daytime-twilight.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference daytime - Twilight","feature_key":"preference_daytime","property_key":"twilight","platform":"android","amount":1528590,"percentage":18.62}
+{"name":"Android - Preference daytime - Twilight","feature_key":"preference_daytime","property_key":"twilight","platform":"android","amount":1531224,"percentage":18.67}

--- a/src/data/generated/data-features/android-preference_daytime-twilight.json
+++ b/src/data/generated/data-features/android-preference_daytime-twilight.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference daytime - Twilight","feature_key":"preference_daytime","property_key":"twilight","platform":"android","amount":1531224,"percentage":18.67}
+{"name":"Android - Preference daytime - Twilight","feature_key":"preference_daytime","property_key":"twilight","platform":"android","amount":1537229,"percentage":18.73}

--- a/src/data/generated/data-features/android-preference_daytime-unknown.json
+++ b/src/data/generated/data-features/android-preference_daytime-unknown.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference daytime - Unknown","feature_key":"preference_daytime","property_key":"unknown","platform":"android","amount":1198648,"percentage":16.71}
+{"name":"Android - Preference daytime - Unknown","feature_key":"preference_daytime","property_key":"unknown","platform":"android","amount":1198405,"percentage":16.7}

--- a/src/data/generated/data-features/android-preference_daytime-unknown.json
+++ b/src/data/generated/data-features/android-preference_daytime-unknown.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference daytime - Unknown","feature_key":"preference_daytime","property_key":"unknown","platform":"android","amount":1198405,"percentage":16.7}
+{"name":"Android - Preference daytime - Unknown","feature_key":"preference_daytime","property_key":"unknown","platform":"android","amount":1198328,"percentage":16.68}

--- a/src/data/generated/data-features/android-preference_daytime-unknown.json
+++ b/src/data/generated/data-features/android-preference_daytime-unknown.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference daytime - Unknown","feature_key":"preference_daytime","property_key":"unknown","platform":"android","amount":1203745,"percentage":16.77}
+{"name":"Android - Preference daytime - Unknown","feature_key":"preference_daytime","property_key":"unknown","platform":"android","amount":1198648,"percentage":16.71}

--- a/src/data/generated/data-features/android-preference_daytime-unknown.json
+++ b/src/data/generated/data-features/android-preference_daytime-unknown.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference daytime - Unknown","feature_key":"preference_daytime","property_key":"unknown","platform":"android","amount":1204713,"percentage":16.79}
+{"name":"Android - Preference daytime - Unknown","feature_key":"preference_daytime","property_key":"unknown","platform":"android","amount":1203745,"percentage":16.77}

--- a/src/data/generated/data-features/android-preference_font_weight_adjustment-0.json
+++ b/src/data/generated/data-features/android-preference_font_weight_adjustment-0.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference font weight adjustment - 0","feature_key":"preference_font_weight_adjustment","property_key":"0","platform":"android","amount":4380402,"percentage":55.13}
+{"name":"Android - Preference font weight adjustment - 0","feature_key":"preference_font_weight_adjustment","property_key":"0","platform":"android","amount":4387015,"percentage":55.16}

--- a/src/data/generated/data-features/android-preference_font_weight_adjustment-0.json
+++ b/src/data/generated/data-features/android-preference_font_weight_adjustment-0.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference font weight adjustment - 0","feature_key":"preference_font_weight_adjustment","property_key":"0","platform":"android","amount":4387015,"percentage":55.16}
+{"name":"Android - Preference font weight adjustment - 0","feature_key":"preference_font_weight_adjustment","property_key":"0","platform":"android","amount":4393806,"percentage":55.19}

--- a/src/data/generated/data-features/android-preference_font_weight_adjustment-0.json
+++ b/src/data/generated/data-features/android-preference_font_weight_adjustment-0.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference font weight adjustment - 0","feature_key":"preference_font_weight_adjustment","property_key":"0","platform":"android","amount":4373870,"percentage":55.11}
+{"name":"Android - Preference font weight adjustment - 0","feature_key":"preference_font_weight_adjustment","property_key":"0","platform":"android","amount":4380402,"percentage":55.13}

--- a/src/data/generated/data-features/android-preference_font_weight_adjustment-0.json
+++ b/src/data/generated/data-features/android-preference_font_weight_adjustment-0.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference font weight adjustment - 0","feature_key":"preference_font_weight_adjustment","property_key":"0","platform":"android","amount":4369958,"percentage":55.09}
+{"name":"Android - Preference font weight adjustment - 0","feature_key":"preference_font_weight_adjustment","property_key":"0","platform":"android","amount":4373870,"percentage":55.11}

--- a/src/data/generated/data-features/android-preference_font_weight_adjustment-200.json
+++ b/src/data/generated/data-features/android-preference_font_weight_adjustment-200.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference font weight adjustment - 200","feature_key":"preference_font_weight_adjustment","property_key":"200","platform":"android","amount":230,"percentage":0}
+{"name":"Android - Preference font weight adjustment - 200","feature_key":"preference_font_weight_adjustment","property_key":"200","platform":"android","amount":231,"percentage":0}

--- a/src/data/generated/data-features/android-preference_font_weight_adjustment-300.json
+++ b/src/data/generated/data-features/android-preference_font_weight_adjustment-300.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference font weight adjustment - 300","feature_key":"preference_font_weight_adjustment","property_key":"300","platform":"android","amount":241413,"percentage":3}
+{"name":"Android - Preference font weight adjustment - 300","feature_key":"preference_font_weight_adjustment","property_key":"300","platform":"android","amount":241963,"percentage":3}

--- a/src/data/generated/data-features/android-preference_font_weight_adjustment-300.json
+++ b/src/data/generated/data-features/android-preference_font_weight_adjustment-300.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference font weight adjustment - 300","feature_key":"preference_font_weight_adjustment","property_key":"300","platform":"android","amount":242403,"percentage":3}
+{"name":"Android - Preference font weight adjustment - 300","feature_key":"preference_font_weight_adjustment","property_key":"300","platform":"android","amount":242906,"percentage":3}

--- a/src/data/generated/data-features/android-preference_font_weight_adjustment-300.json
+++ b/src/data/generated/data-features/android-preference_font_weight_adjustment-300.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference font weight adjustment - 300","feature_key":"preference_font_weight_adjustment","property_key":"300","platform":"android","amount":241098,"percentage":3}
+{"name":"Android - Preference font weight adjustment - 300","feature_key":"preference_font_weight_adjustment","property_key":"300","platform":"android","amount":241413,"percentage":3}

--- a/src/data/generated/data-features/android-preference_font_weight_adjustment-300.json
+++ b/src/data/generated/data-features/android-preference_font_weight_adjustment-300.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference font weight adjustment - 300","feature_key":"preference_font_weight_adjustment","property_key":"300","platform":"android","amount":241963,"percentage":3}
+{"name":"Android - Preference font weight adjustment - 300","feature_key":"preference_font_weight_adjustment","property_key":"300","platform":"android","amount":242403,"percentage":3}

--- a/src/data/generated/data-features/android-preference_is_nightmode_enabled-false.json
+++ b/src/data/generated/data-features/android-preference_is_nightmode_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference is nightmode enabled - False","feature_key":"preference_is_nightmode_enabled","property_key":"false","platform":"android","amount":5229916,"percentage":68.51}
+{"name":"Android - Preference is nightmode enabled - False","feature_key":"preference_is_nightmode_enabled","property_key":"false","platform":"android","amount":5231076,"percentage":68.48}

--- a/src/data/generated/data-features/android-preference_is_nightmode_enabled-false.json
+++ b/src/data/generated/data-features/android-preference_is_nightmode_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference is nightmode enabled - False","feature_key":"preference_is_nightmode_enabled","property_key":"false","platform":"android","amount":5231076,"percentage":68.48}
+{"name":"Android - Preference is nightmode enabled - False","feature_key":"preference_is_nightmode_enabled","property_key":"false","platform":"android","amount":5232314,"percentage":68.44}

--- a/src/data/generated/data-features/android-preference_is_nightmode_enabled-false.json
+++ b/src/data/generated/data-features/android-preference_is_nightmode_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference is nightmode enabled - False","feature_key":"preference_is_nightmode_enabled","property_key":"false","platform":"android","amount":5236705,"percentage":68.44}
+{"name":"Android - Preference is nightmode enabled - False","feature_key":"preference_is_nightmode_enabled","property_key":"false","platform":"android","amount":5240537,"percentage":68.41}

--- a/src/data/generated/data-features/android-preference_is_nightmode_enabled-false.json
+++ b/src/data/generated/data-features/android-preference_is_nightmode_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference is nightmode enabled - False","feature_key":"preference_is_nightmode_enabled","property_key":"false","platform":"android","amount":5232314,"percentage":68.44}
+{"name":"Android - Preference is nightmode enabled - False","feature_key":"preference_is_nightmode_enabled","property_key":"false","platform":"android","amount":5236705,"percentage":68.44}

--- a/src/data/generated/data-features/android-preference_is_nightmode_enabled-true.json
+++ b/src/data/generated/data-features/android-preference_is_nightmode_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference is nightmode enabled - True","feature_key":"preference_is_nightmode_enabled","property_key":"true","platform":"android","amount":2135796,"percentage":25.54}
+{"name":"Android - Preference is nightmode enabled - True","feature_key":"preference_is_nightmode_enabled","property_key":"true","platform":"android","amount":2139582,"percentage":25.57}

--- a/src/data/generated/data-features/android-preference_is_nightmode_enabled-true.json
+++ b/src/data/generated/data-features/android-preference_is_nightmode_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference is nightmode enabled - True","feature_key":"preference_is_nightmode_enabled","property_key":"true","platform":"android","amount":2126370,"percentage":25.48}
+{"name":"Android - Preference is nightmode enabled - True","feature_key":"preference_is_nightmode_enabled","property_key":"true","platform":"android","amount":2132669,"percentage":25.52}

--- a/src/data/generated/data-features/android-preference_is_nightmode_enabled-true.json
+++ b/src/data/generated/data-features/android-preference_is_nightmode_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference is nightmode enabled - True","feature_key":"preference_is_nightmode_enabled","property_key":"true","platform":"android","amount":2123087,"percentage":25.45}
+{"name":"Android - Preference is nightmode enabled - True","feature_key":"preference_is_nightmode_enabled","property_key":"true","platform":"android","amount":2126370,"percentage":25.48}

--- a/src/data/generated/data-features/android-preference_is_nightmode_enabled-true.json
+++ b/src/data/generated/data-features/android-preference_is_nightmode_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Android - Preference is nightmode enabled - True","feature_key":"preference_is_nightmode_enabled","property_key":"true","platform":"android","amount":2132669,"percentage":25.52}
+{"name":"Android - Preference is nightmode enabled - True","feature_key":"preference_is_nightmode_enabled","property_key":"true","platform":"android","amount":2135796,"percentage":25.54}

--- a/src/data/generated/data-features/android-screen_display_scale_default_comparison-bigger.json
+++ b/src/data/generated/data-features/android-screen_display_scale_default_comparison-bigger.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen display scale default comparison - Bigger","feature_key":"screen_display_scale_default_comparison","property_key":"bigger","platform":"android","amount":1280971,"percentage":16.14}
+{"name":"Android - Screen display scale default comparison - Bigger","feature_key":"screen_display_scale_default_comparison","property_key":"bigger","platform":"android","amount":1282488,"percentage":16.14}

--- a/src/data/generated/data-features/android-screen_display_scale_default_comparison-bigger.json
+++ b/src/data/generated/data-features/android-screen_display_scale_default_comparison-bigger.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen display scale default comparison - Bigger","feature_key":"screen_display_scale_default_comparison","property_key":"bigger","platform":"android","amount":1280208,"percentage":16.14}
+{"name":"Android - Screen display scale default comparison - Bigger","feature_key":"screen_display_scale_default_comparison","property_key":"bigger","platform":"android","amount":1280971,"percentage":16.14}

--- a/src/data/generated/data-features/android-screen_display_scale_default_comparison-bigger.json
+++ b/src/data/generated/data-features/android-screen_display_scale_default_comparison-bigger.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen display scale default comparison - Bigger","feature_key":"screen_display_scale_default_comparison","property_key":"bigger","platform":"android","amount":1283868,"percentage":16.14}
+{"name":"Android - Screen display scale default comparison - Bigger","feature_key":"screen_display_scale_default_comparison","property_key":"bigger","platform":"android","amount":1285266,"percentage":16.15}

--- a/src/data/generated/data-features/android-screen_display_scale_default_comparison-bigger.json
+++ b/src/data/generated/data-features/android-screen_display_scale_default_comparison-bigger.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen display scale default comparison - Bigger","feature_key":"screen_display_scale_default_comparison","property_key":"bigger","platform":"android","amount":1282488,"percentage":16.14}
+{"name":"Android - Screen display scale default comparison - Bigger","feature_key":"screen_display_scale_default_comparison","property_key":"bigger","platform":"android","amount":1283868,"percentage":16.14}

--- a/src/data/generated/data-features/android-screen_display_scale_default_comparison-default.json
+++ b/src/data/generated/data-features/android-screen_display_scale_default_comparison-default.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen display scale default comparison - Default","feature_key":"screen_display_scale_default_comparison","property_key":"default","platform":"android","amount":5778064,"percentage":73.81}
+{"name":"Android - Screen display scale default comparison - Default","feature_key":"screen_display_scale_default_comparison","property_key":"default","platform":"android","amount":5783466,"percentage":73.8}

--- a/src/data/generated/data-features/android-screen_display_scale_default_comparison-default.json
+++ b/src/data/generated/data-features/android-screen_display_scale_default_comparison-default.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen display scale default comparison - Default","feature_key":"screen_display_scale_default_comparison","property_key":"default","platform":"android","amount":5783466,"percentage":73.8}
+{"name":"Android - Screen display scale default comparison - Default","feature_key":"screen_display_scale_default_comparison","property_key":"default","platform":"android","amount":5788950,"percentage":73.8}

--- a/src/data/generated/data-features/android-screen_display_scale_default_comparison-default.json
+++ b/src/data/generated/data-features/android-screen_display_scale_default_comparison-default.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen display scale default comparison - Default","feature_key":"screen_display_scale_default_comparison","property_key":"default","platform":"android","amount":5772812,"percentage":73.81}
+{"name":"Android - Screen display scale default comparison - Default","feature_key":"screen_display_scale_default_comparison","property_key":"default","platform":"android","amount":5778064,"percentage":73.81}

--- a/src/data/generated/data-features/android-screen_display_scale_default_comparison-default.json
+++ b/src/data/generated/data-features/android-screen_display_scale_default_comparison-default.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen display scale default comparison - Default","feature_key":"screen_display_scale_default_comparison","property_key":"default","platform":"android","amount":5768124,"percentage":73.79}
+{"name":"Android - Screen display scale default comparison - Default","feature_key":"screen_display_scale_default_comparison","property_key":"default","platform":"android","amount":5772812,"percentage":73.81}

--- a/src/data/generated/data-features/android-screen_display_scale_default_comparison-smaller.json
+++ b/src/data/generated/data-features/android-screen_display_scale_default_comparison-smaller.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen display scale default comparison - Smaller","feature_key":"screen_display_scale_default_comparison","property_key":"smaller","platform":"android","amount":786526,"percentage":9.82}
+{"name":"Android - Screen display scale default comparison - Smaller","feature_key":"screen_display_scale_default_comparison","property_key":"smaller","platform":"android","amount":787361,"percentage":9.82}

--- a/src/data/generated/data-features/android-screen_display_scale_default_comparison-smaller.json
+++ b/src/data/generated/data-features/android-screen_display_scale_default_comparison-smaller.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen display scale default comparison - Smaller","feature_key":"screen_display_scale_default_comparison","property_key":"smaller","platform":"android","amount":784796,"percentage":9.81}
+{"name":"Android - Screen display scale default comparison - Smaller","feature_key":"screen_display_scale_default_comparison","property_key":"smaller","platform":"android","amount":785685,"percentage":9.82}

--- a/src/data/generated/data-features/android-screen_display_scale_default_comparison-smaller.json
+++ b/src/data/generated/data-features/android-screen_display_scale_default_comparison-smaller.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen display scale default comparison - Smaller","feature_key":"screen_display_scale_default_comparison","property_key":"smaller","platform":"android","amount":783856,"percentage":9.8}
+{"name":"Android - Screen display scale default comparison - Smaller","feature_key":"screen_display_scale_default_comparison","property_key":"smaller","platform":"android","amount":784796,"percentage":9.81}

--- a/src/data/generated/data-features/android-screen_display_scale_default_comparison-smaller.json
+++ b/src/data/generated/data-features/android-screen_display_scale_default_comparison-smaller.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen display scale default comparison - Smaller","feature_key":"screen_display_scale_default_comparison","property_key":"smaller","platform":"android","amount":785685,"percentage":9.82}
+{"name":"Android - Screen display scale default comparison - Smaller","feature_key":"screen_display_scale_default_comparison","property_key":"smaller","platform":"android","amount":786526,"percentage":9.82}

--- a/src/data/generated/data-features/android-screen_font_scale_default_comparison-bigger.json
+++ b/src/data/generated/data-features/android-screen_font_scale_default_comparison-bigger.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen font scale default comparison - Bigger","feature_key":"screen_font_scale_default_comparison","property_key":"bigger","platform":"android","amount":1938762,"percentage":24.64}
+{"name":"Android - Screen font scale default comparison - Bigger","feature_key":"screen_font_scale_default_comparison","property_key":"bigger","platform":"android","amount":1941075,"percentage":24.65}

--- a/src/data/generated/data-features/android-screen_font_scale_default_comparison-bigger.json
+++ b/src/data/generated/data-features/android-screen_font_scale_default_comparison-bigger.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen font scale default comparison - Bigger","feature_key":"screen_font_scale_default_comparison","property_key":"bigger","platform":"android","amount":1943172,"percentage":24.65}
+{"name":"Android - Screen font scale default comparison - Bigger","feature_key":"screen_font_scale_default_comparison","property_key":"bigger","platform":"android","amount":1945482,"percentage":24.66}

--- a/src/data/generated/data-features/android-screen_font_scale_default_comparison-bigger.json
+++ b/src/data/generated/data-features/android-screen_font_scale_default_comparison-bigger.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen font scale default comparison - Bigger","feature_key":"screen_font_scale_default_comparison","property_key":"bigger","platform":"android","amount":1941075,"percentage":24.65}
+{"name":"Android - Screen font scale default comparison - Bigger","feature_key":"screen_font_scale_default_comparison","property_key":"bigger","platform":"android","amount":1943172,"percentage":24.65}

--- a/src/data/generated/data-features/android-screen_font_scale_default_comparison-bigger.json
+++ b/src/data/generated/data-features/android-screen_font_scale_default_comparison-bigger.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen font scale default comparison - Bigger","feature_key":"screen_font_scale_default_comparison","property_key":"bigger","platform":"android","amount":1936890,"percentage":24.63}
+{"name":"Android - Screen font scale default comparison - Bigger","feature_key":"screen_font_scale_default_comparison","property_key":"bigger","platform":"android","amount":1938762,"percentage":24.64}

--- a/src/data/generated/data-features/android-screen_font_scale_default_comparison-default.json
+++ b/src/data/generated/data-features/android-screen_font_scale_default_comparison-default.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen font scale default comparison - Default","feature_key":"screen_font_scale_default_comparison","property_key":"default","platform":"android","amount":4919922,"percentage":62.47}
+{"name":"Android - Screen font scale default comparison - Default","feature_key":"screen_font_scale_default_comparison","property_key":"default","platform":"android","amount":4924782,"percentage":62.47}

--- a/src/data/generated/data-features/android-screen_font_scale_default_comparison-default.json
+++ b/src/data/generated/data-features/android-screen_font_scale_default_comparison-default.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen font scale default comparison - Default","feature_key":"screen_font_scale_default_comparison","property_key":"default","platform":"android","amount":4911162,"percentage":62.45}
+{"name":"Android - Screen font scale default comparison - Default","feature_key":"screen_font_scale_default_comparison","property_key":"default","platform":"android","amount":4915291,"percentage":62.47}

--- a/src/data/generated/data-features/android-screen_font_scale_default_comparison-default.json
+++ b/src/data/generated/data-features/android-screen_font_scale_default_comparison-default.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen font scale default comparison - Default","feature_key":"screen_font_scale_default_comparison","property_key":"default","platform":"android","amount":4915291,"percentage":62.47}
+{"name":"Android - Screen font scale default comparison - Default","feature_key":"screen_font_scale_default_comparison","property_key":"default","platform":"android","amount":4919922,"percentage":62.47}

--- a/src/data/generated/data-features/android-screen_font_scale_default_comparison-default.json
+++ b/src/data/generated/data-features/android-screen_font_scale_default_comparison-default.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen font scale default comparison - Default","feature_key":"screen_font_scale_default_comparison","property_key":"default","platform":"android","amount":4924782,"percentage":62.47}
+{"name":"Android - Screen font scale default comparison - Default","feature_key":"screen_font_scale_default_comparison","property_key":"default","platform":"android","amount":4929565,"percentage":62.46}

--- a/src/data/generated/data-features/android-screen_font_scale_default_comparison-smaller.json
+++ b/src/data/generated/data-features/android-screen_font_scale_default_comparison-smaller.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen font scale default comparison - Smaller","feature_key":"screen_font_scale_default_comparison","property_key":"smaller","platform":"android","amount":984136,"percentage":12.66}
+{"name":"Android - Screen font scale default comparison - Smaller","feature_key":"screen_font_scale_default_comparison","property_key":"smaller","platform":"android","amount":984526,"percentage":12.66}

--- a/src/data/generated/data-features/android-screen_font_scale_default_comparison-smaller.json
+++ b/src/data/generated/data-features/android-screen_font_scale_default_comparison-smaller.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen font scale default comparison - Smaller","feature_key":"screen_font_scale_default_comparison","property_key":"smaller","platform":"android","amount":984526,"percentage":12.66}
+{"name":"Android - Screen font scale default comparison - Smaller","feature_key":"screen_font_scale_default_comparison","property_key":"smaller","platform":"android","amount":985240,"percentage":12.64}

--- a/src/data/generated/data-features/android-screen_font_scale_default_comparison-smaller.json
+++ b/src/data/generated/data-features/android-screen_font_scale_default_comparison-smaller.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen font scale default comparison - Smaller","feature_key":"screen_font_scale_default_comparison","property_key":"smaller","platform":"android","amount":985906,"percentage":12.64}
+{"name":"Android - Screen font scale default comparison - Smaller","feature_key":"screen_font_scale_default_comparison","property_key":"smaller","platform":"android","amount":986530,"percentage":12.64}

--- a/src/data/generated/data-features/android-screen_font_scale_default_comparison-smaller.json
+++ b/src/data/generated/data-features/android-screen_font_scale_default_comparison-smaller.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen font scale default comparison - Smaller","feature_key":"screen_font_scale_default_comparison","property_key":"smaller","platform":"android","amount":985240,"percentage":12.64}
+{"name":"Android - Screen font scale default comparison - Smaller","feature_key":"screen_font_scale_default_comparison","property_key":"smaller","platform":"android","amount":985906,"percentage":12.64}

--- a/src/data/generated/data-features/android-screen_orientation-landscape.json
+++ b/src/data/generated/data-features/android-screen_orientation-landscape.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen orientation - Landscape","feature_key":"screen_orientation","property_key":"landscape","platform":"android","amount":148370,"percentage":1.67}
+{"name":"Android - Screen orientation - Landscape","feature_key":"screen_orientation","property_key":"landscape","platform":"android","amount":149140,"percentage":1.68}

--- a/src/data/generated/data-features/android-screen_orientation-landscape.json
+++ b/src/data/generated/data-features/android-screen_orientation-landscape.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen orientation - Landscape","feature_key":"screen_orientation","property_key":"landscape","platform":"android","amount":149140,"percentage":1.68}
+{"name":"Android - Screen orientation - Landscape","feature_key":"screen_orientation","property_key":"landscape","platform":"android","amount":149540,"percentage":1.69}

--- a/src/data/generated/data-features/android-screen_orientation-landscape.json
+++ b/src/data/generated/data-features/android-screen_orientation-landscape.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen orientation - Landscape","feature_key":"screen_orientation","property_key":"landscape","platform":"android","amount":149540,"percentage":1.69}
+{"name":"Android - Screen orientation - Landscape","feature_key":"screen_orientation","property_key":"landscape","platform":"android","amount":149971,"percentage":1.69}

--- a/src/data/generated/data-features/android-screen_orientation-landscape.json
+++ b/src/data/generated/data-features/android-screen_orientation-landscape.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen orientation - Landscape","feature_key":"screen_orientation","property_key":"landscape","platform":"android","amount":147410,"percentage":1.66}
+{"name":"Android - Screen orientation - Landscape","feature_key":"screen_orientation","property_key":"landscape","platform":"android","amount":148370,"percentage":1.67}

--- a/src/data/generated/data-features/android-screen_orientation-portrait.json
+++ b/src/data/generated/data-features/android-screen_orientation-portrait.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen orientation - Portrait","feature_key":"screen_orientation","property_key":"portrait","platform":"android","amount":7716599,"percentage":98.33}
+{"name":"Android - Screen orientation - Portrait","feature_key":"screen_orientation","property_key":"portrait","platform":"android","amount":7723514,"percentage":98.32}

--- a/src/data/generated/data-features/android-screen_orientation-portrait.json
+++ b/src/data/generated/data-features/android-screen_orientation-portrait.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen orientation - Portrait","feature_key":"screen_orientation","property_key":"portrait","platform":"android","amount":7730761,"percentage":98.31}
+{"name":"Android - Screen orientation - Portrait","feature_key":"screen_orientation","property_key":"portrait","platform":"android","amount":7738078,"percentage":98.31}

--- a/src/data/generated/data-features/android-screen_orientation-portrait.json
+++ b/src/data/generated/data-features/android-screen_orientation-portrait.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen orientation - Portrait","feature_key":"screen_orientation","property_key":"portrait","platform":"android","amount":7713031,"percentage":98.34}
+{"name":"Android - Screen orientation - Portrait","feature_key":"screen_orientation","property_key":"portrait","platform":"android","amount":7716599,"percentage":98.33}

--- a/src/data/generated/data-features/android-screen_orientation-portrait.json
+++ b/src/data/generated/data-features/android-screen_orientation-portrait.json
@@ -1,1 +1,1 @@
-{"name":"Android - Screen orientation - Portrait","feature_key":"screen_orientation","property_key":"portrait","platform":"android","amount":7723514,"percentage":98.32}
+{"name":"Android - Screen orientation - Portrait","feature_key":"screen_orientation","property_key":"portrait","platform":"android","amount":7730761,"percentage":98.31}

--- a/src/data/generated/data-features/ios-accessibility_features-1+.json
+++ b/src/data/generated/data-features/ios-accessibility_features-1+.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility features - 1+","feature_key":"accessibility_features","property_key":"1+","platform":"ios","amount":2953740,"percentage":46.59}
+{"name":"Ios - Accessibility features - 1+","feature_key":"accessibility_features","property_key":"1+","platform":"ios","amount":2954096,"percentage":46.59}

--- a/src/data/generated/data-features/ios-accessibility_features-1+.json
+++ b/src/data/generated/data-features/ios-accessibility_features-1+.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility features - 1+","feature_key":"accessibility_features","property_key":"1+","platform":"ios","amount":2953211,"percentage":46.59}
+{"name":"Ios - Accessibility features - 1+","feature_key":"accessibility_features","property_key":"1+","platform":"ios","amount":2953398,"percentage":46.59}

--- a/src/data/generated/data-features/ios-accessibility_features-1+.json
+++ b/src/data/generated/data-features/ios-accessibility_features-1+.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility features - 1+","feature_key":"accessibility_features","property_key":"1+","platform":"ios","amount":2953398,"percentage":46.59}
+{"name":"Ios - Accessibility features - 1+","feature_key":"accessibility_features","property_key":"1+","platform":"ios","amount":2953740,"percentage":46.59}

--- a/src/data/generated/data-features/ios-accessibility_features-1+.json
+++ b/src/data/generated/data-features/ios-accessibility_features-1+.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility features - 1+","feature_key":"accessibility_features","property_key":"1+","platform":"ios","amount":2954096,"percentage":46.59}
+{"name":"Ios - Accessibility features - 1+","feature_key":"accessibility_features","property_key":"1+","platform":"ios","amount":2954479,"percentage":46.59}

--- a/src/data/generated/data-features/ios-accessibility_features-2+.json
+++ b/src/data/generated/data-features/ios-accessibility_features-2+.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility features - 2+","feature_key":"accessibility_features","property_key":"2+","platform":"ios","amount":1058080,"percentage":16.34}
+{"name":"Ios - Accessibility features - 2+","feature_key":"accessibility_features","property_key":"2+","platform":"ios","amount":1058222,"percentage":16.34}

--- a/src/data/generated/data-features/ios-accessibility_features-2+.json
+++ b/src/data/generated/data-features/ios-accessibility_features-2+.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility features - 2+","feature_key":"accessibility_features","property_key":"2+","platform":"ios","amount":1058222,"percentage":16.34}
+{"name":"Ios - Accessibility features - 2+","feature_key":"accessibility_features","property_key":"2+","platform":"ios","amount":1058393,"percentage":16.34}

--- a/src/data/generated/data-features/ios-accessibility_features-2+.json
+++ b/src/data/generated/data-features/ios-accessibility_features-2+.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility features - 2+","feature_key":"accessibility_features","property_key":"2+","platform":"ios","amount":1057942,"percentage":16.34}
+{"name":"Ios - Accessibility features - 2+","feature_key":"accessibility_features","property_key":"2+","platform":"ios","amount":1058080,"percentage":16.34}

--- a/src/data/generated/data-features/ios-accessibility_features-2+.json
+++ b/src/data/generated/data-features/ios-accessibility_features-2+.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility features - 2+","feature_key":"accessibility_features","property_key":"2+","platform":"ios","amount":1057880,"percentage":16.34}
+{"name":"Ios - Accessibility features - 2+","feature_key":"accessibility_features","property_key":"2+","platform":"ios","amount":1057942,"percentage":16.34}

--- a/src/data/generated/data-features/ios-accessibility_is_assistive_touch_running_with_is_guided_access_enabled-Unknown.json
+++ b/src/data/generated/data-features/ios-accessibility_is_assistive_touch_running_with_is_guided_access_enabled-Unknown.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is assistive touch running with is guided access enabled - Unknown","feature_key":"accessibility_is_assistive_touch_running_with_is_guided_access_enabled","property_key":"Unknown","platform":"ios","amount":6270636,"percentage":100}
+{"name":"Ios - Accessibility is assistive touch running with is guided access enabled - Unknown","feature_key":"accessibility_is_assistive_touch_running_with_is_guided_access_enabled","property_key":"Unknown","platform":"ios","amount":6271437,"percentage":100}

--- a/src/data/generated/data-features/ios-accessibility_is_assistive_touch_running_with_is_guided_access_enabled-Unknown.json
+++ b/src/data/generated/data-features/ios-accessibility_is_assistive_touch_running_with_is_guided_access_enabled-Unknown.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is assistive touch running with is guided access enabled - Unknown","feature_key":"accessibility_is_assistive_touch_running_with_is_guided_access_enabled","property_key":"Unknown","platform":"ios","amount":6269837,"percentage":100}
+{"name":"Ios - Accessibility is assistive touch running with is guided access enabled - Unknown","feature_key":"accessibility_is_assistive_touch_running_with_is_guided_access_enabled","property_key":"Unknown","platform":"ios","amount":6270636,"percentage":100}

--- a/src/data/generated/data-features/ios-accessibility_is_assistive_touch_running_with_is_guided_access_enabled-Unknown.json
+++ b/src/data/generated/data-features/ios-accessibility_is_assistive_touch_running_with_is_guided_access_enabled-Unknown.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is assistive touch running with is guided access enabled - Unknown","feature_key":"accessibility_is_assistive_touch_running_with_is_guided_access_enabled","property_key":"Unknown","platform":"ios","amount":6268585,"percentage":100}
+{"name":"Ios - Accessibility is assistive touch running with is guided access enabled - Unknown","feature_key":"accessibility_is_assistive_touch_running_with_is_guided_access_enabled","property_key":"Unknown","platform":"ios","amount":6269046,"percentage":100}

--- a/src/data/generated/data-features/ios-accessibility_is_assistive_touch_running_with_is_guided_access_enabled-Unknown.json
+++ b/src/data/generated/data-features/ios-accessibility_is_assistive_touch_running_with_is_guided_access_enabled-Unknown.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is assistive touch running with is guided access enabled - Unknown","feature_key":"accessibility_is_assistive_touch_running_with_is_guided_access_enabled","property_key":"Unknown","platform":"ios","amount":6269046,"percentage":100}
+{"name":"Ios - Accessibility is assistive touch running with is guided access enabled - Unknown","feature_key":"accessibility_is_assistive_touch_running_with_is_guided_access_enabled","property_key":"Unknown","platform":"ios","amount":6269837,"percentage":100}

--- a/src/data/generated/data-features/ios-accessibility_is_bold_text_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_bold_text_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is bold text enabled - False","feature_key":"accessibility_is_bold_text_enabled","property_key":"false","platform":"ios","amount":5637349,"percentage":90.07}
+{"name":"Ios - Accessibility is bold text enabled - False","feature_key":"accessibility_is_bold_text_enabled","property_key":"false","platform":"ios","amount":5638033,"percentage":90.06}

--- a/src/data/generated/data-features/ios-accessibility_is_bold_text_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_bold_text_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is bold text enabled - False","feature_key":"accessibility_is_bold_text_enabled","property_key":"false","platform":"ios","amount":5636632,"percentage":90.07}
+{"name":"Ios - Accessibility is bold text enabled - False","feature_key":"accessibility_is_bold_text_enabled","property_key":"false","platform":"ios","amount":5637349,"percentage":90.07}

--- a/src/data/generated/data-features/ios-accessibility_is_bold_text_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_bold_text_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is bold text enabled - False","feature_key":"accessibility_is_bold_text_enabled","property_key":"false","platform":"ios","amount":5635950,"percentage":90.07}
+{"name":"Ios - Accessibility is bold text enabled - False","feature_key":"accessibility_is_bold_text_enabled","property_key":"false","platform":"ios","amount":5636632,"percentage":90.07}

--- a/src/data/generated/data-features/ios-accessibility_is_bold_text_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_bold_text_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is bold text enabled - False","feature_key":"accessibility_is_bold_text_enabled","property_key":"false","platform":"ios","amount":5635537,"percentage":90.07}
+{"name":"Ios - Accessibility is bold text enabled - False","feature_key":"accessibility_is_bold_text_enabled","property_key":"false","platform":"ios","amount":5635950,"percentage":90.07}

--- a/src/data/generated/data-features/ios-accessibility_is_bold_text_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_bold_text_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is bold text enabled - True","feature_key":"accessibility_is_bold_text_enabled","property_key":"true","platform":"ios","amount":633048,"percentage":9.93}
+{"name":"Ios - Accessibility is bold text enabled - True","feature_key":"accessibility_is_bold_text_enabled","property_key":"true","platform":"ios","amount":633096,"percentage":9.93}

--- a/src/data/generated/data-features/ios-accessibility_is_bold_text_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_bold_text_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is bold text enabled - True","feature_key":"accessibility_is_bold_text_enabled","property_key":"true","platform":"ios","amount":633287,"percentage":9.93}
+{"name":"Ios - Accessibility is bold text enabled - True","feature_key":"accessibility_is_bold_text_enabled","property_key":"true","platform":"ios","amount":633404,"percentage":9.94}

--- a/src/data/generated/data-features/ios-accessibility_is_bold_text_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_bold_text_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is bold text enabled - True","feature_key":"accessibility_is_bold_text_enabled","property_key":"true","platform":"ios","amount":633205,"percentage":9.93}
+{"name":"Ios - Accessibility is bold text enabled - True","feature_key":"accessibility_is_bold_text_enabled","property_key":"true","platform":"ios","amount":633287,"percentage":9.93}

--- a/src/data/generated/data-features/ios-accessibility_is_bold_text_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_bold_text_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is bold text enabled - True","feature_key":"accessibility_is_bold_text_enabled","property_key":"true","platform":"ios","amount":633096,"percentage":9.93}
+{"name":"Ios - Accessibility is bold text enabled - True","feature_key":"accessibility_is_bold_text_enabled","property_key":"true","platform":"ios","amount":633205,"percentage":9.93}

--- a/src/data/generated/data-features/ios-accessibility_is_closed_captioning_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_closed_captioning_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is closed captioning enabled - False","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"false","platform":"ios","amount":6191756,"percentage":98.83}
+{"name":"Ios - Accessibility is closed captioning enabled - False","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"false","platform":"ios","amount":6192541,"percentage":98.83}

--- a/src/data/generated/data-features/ios-accessibility_is_closed_captioning_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_closed_captioning_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is closed captioning enabled - False","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"false","platform":"ios","amount":6192541,"percentage":98.83}
+{"name":"Ios - Accessibility is closed captioning enabled - False","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"false","platform":"ios","amount":6193330,"percentage":98.83}

--- a/src/data/generated/data-features/ios-accessibility_is_closed_captioning_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_closed_captioning_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is closed captioning enabled - False","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"false","platform":"ios","amount":6193330,"percentage":98.83}
+{"name":"Ios - Accessibility is closed captioning enabled - False","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"false","platform":"ios","amount":6194118,"percentage":98.83}

--- a/src/data/generated/data-features/ios-accessibility_is_closed_captioning_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_closed_captioning_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is closed captioning enabled - False","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"false","platform":"ios","amount":6191298,"percentage":98.83}
+{"name":"Ios - Accessibility is closed captioning enabled - False","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"false","platform":"ios","amount":6191756,"percentage":98.83}

--- a/src/data/generated/data-features/ios-accessibility_is_closed_captioning_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_closed_captioning_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is closed captioning enabled - True","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"true","platform":"ios","amount":77296,"percentage":1.17}
+{"name":"Ios - Accessibility is closed captioning enabled - True","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"true","platform":"ios","amount":77306,"percentage":1.17}

--- a/src/data/generated/data-features/ios-accessibility_is_closed_captioning_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_closed_captioning_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is closed captioning enabled - True","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"true","platform":"ios","amount":77287,"percentage":1.17}
+{"name":"Ios - Accessibility is closed captioning enabled - True","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"true","platform":"ios","amount":77290,"percentage":1.17}

--- a/src/data/generated/data-features/ios-accessibility_is_closed_captioning_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_closed_captioning_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is closed captioning enabled - True","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"true","platform":"ios","amount":77290,"percentage":1.17}
+{"name":"Ios - Accessibility is closed captioning enabled - True","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"true","platform":"ios","amount":77296,"percentage":1.17}

--- a/src/data/generated/data-features/ios-accessibility_is_closed_captioning_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_closed_captioning_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is closed captioning enabled - True","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"true","platform":"ios","amount":77306,"percentage":1.17}
+{"name":"Ios - Accessibility is closed captioning enabled - True","feature_key":"accessibility_is_closed_captioning_enabled","property_key":"true","platform":"ios","amount":77319,"percentage":1.17}

--- a/src/data/generated/data-features/ios-accessibility_is_darker_system_colors_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_darker_system_colors_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is darker system colors enabled - False","feature_key":"accessibility_is_darker_system_colors_enabled","property_key":"false","platform":"ios","amount":5995076,"percentage":95.85}
+{"name":"Ios - Accessibility is darker system colors enabled - False","feature_key":"accessibility_is_darker_system_colors_enabled","property_key":"false","platform":"ios","amount":5995834,"percentage":95.85}

--- a/src/data/generated/data-features/ios-accessibility_is_darker_system_colors_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_darker_system_colors_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is darker system colors enabled - False","feature_key":"accessibility_is_darker_system_colors_enabled","property_key":"false","platform":"ios","amount":5995834,"percentage":95.85}
+{"name":"Ios - Accessibility is darker system colors enabled - False","feature_key":"accessibility_is_darker_system_colors_enabled","property_key":"false","platform":"ios","amount":5996605,"percentage":95.85}

--- a/src/data/generated/data-features/ios-accessibility_is_darker_system_colors_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_darker_system_colors_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is darker system colors enabled - False","feature_key":"accessibility_is_darker_system_colors_enabled","property_key":"false","platform":"ios","amount":5993868,"percentage":95.85}
+{"name":"Ios - Accessibility is darker system colors enabled - False","feature_key":"accessibility_is_darker_system_colors_enabled","property_key":"false","platform":"ios","amount":5994312,"percentage":95.85}

--- a/src/data/generated/data-features/ios-accessibility_is_darker_system_colors_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_darker_system_colors_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is darker system colors enabled - False","feature_key":"accessibility_is_darker_system_colors_enabled","property_key":"false","platform":"ios","amount":5994312,"percentage":95.85}
+{"name":"Ios - Accessibility is darker system colors enabled - False","feature_key":"accessibility_is_darker_system_colors_enabled","property_key":"false","platform":"ios","amount":5995076,"percentage":95.85}

--- a/src/data/generated/data-features/ios-accessibility_is_darker_system_colors_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_darker_system_colors_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is darker system colors enabled - True","feature_key":"accessibility_is_darker_system_colors_enabled","property_key":"true","platform":"ios","amount":274717,"percentage":4.15}
+{"name":"Ios - Accessibility is darker system colors enabled - True","feature_key":"accessibility_is_darker_system_colors_enabled","property_key":"true","platform":"ios","amount":274734,"percentage":4.15}

--- a/src/data/generated/data-features/ios-accessibility_is_darker_system_colors_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_darker_system_colors_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is darker system colors enabled - True","feature_key":"accessibility_is_darker_system_colors_enabled","property_key":"true","platform":"ios","amount":274734,"percentage":4.15}
+{"name":"Ios - Accessibility is darker system colors enabled - True","feature_key":"accessibility_is_darker_system_colors_enabled","property_key":"true","platform":"ios","amount":274761,"percentage":4.15}

--- a/src/data/generated/data-features/ios-accessibility_is_darker_system_colors_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_darker_system_colors_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is darker system colors enabled - True","feature_key":"accessibility_is_darker_system_colors_enabled","property_key":"true","platform":"ios","amount":274802,"percentage":4.15}
+{"name":"Ios - Accessibility is darker system colors enabled - True","feature_key":"accessibility_is_darker_system_colors_enabled","property_key":"true","platform":"ios","amount":274832,"percentage":4.15}

--- a/src/data/generated/data-features/ios-accessibility_is_darker_system_colors_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_darker_system_colors_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is darker system colors enabled - True","feature_key":"accessibility_is_darker_system_colors_enabled","property_key":"true","platform":"ios","amount":274761,"percentage":4.15}
+{"name":"Ios - Accessibility is darker system colors enabled - True","feature_key":"accessibility_is_darker_system_colors_enabled","property_key":"true","platform":"ios","amount":274802,"percentage":4.15}

--- a/src/data/generated/data-features/ios-accessibility_is_grayscale_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_grayscale_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is grayscale enabled - False","feature_key":"accessibility_is_grayscale_enabled","property_key":"false","platform":"ios","amount":6263913,"percentage":99.93}
+{"name":"Ios - Accessibility is grayscale enabled - False","feature_key":"accessibility_is_grayscale_enabled","property_key":"false","platform":"ios","amount":6264371,"percentage":99.93}

--- a/src/data/generated/data-features/ios-accessibility_is_grayscale_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_grayscale_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is grayscale enabled - False","feature_key":"accessibility_is_grayscale_enabled","property_key":"false","platform":"ios","amount":6265161,"percentage":99.93}
+{"name":"Ios - Accessibility is grayscale enabled - False","feature_key":"accessibility_is_grayscale_enabled","property_key":"false","platform":"ios","amount":6265956,"percentage":99.93}

--- a/src/data/generated/data-features/ios-accessibility_is_grayscale_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_grayscale_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is grayscale enabled - False","feature_key":"accessibility_is_grayscale_enabled","property_key":"false","platform":"ios","amount":6265956,"percentage":99.93}
+{"name":"Ios - Accessibility is grayscale enabled - False","feature_key":"accessibility_is_grayscale_enabled","property_key":"false","platform":"ios","amount":6266757,"percentage":99.93}

--- a/src/data/generated/data-features/ios-accessibility_is_grayscale_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_grayscale_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is grayscale enabled - False","feature_key":"accessibility_is_grayscale_enabled","property_key":"false","platform":"ios","amount":6264371,"percentage":99.93}
+{"name":"Ios - Accessibility is grayscale enabled - False","feature_key":"accessibility_is_grayscale_enabled","property_key":"false","platform":"ios","amount":6265161,"percentage":99.93}

--- a/src/data/generated/data-features/ios-accessibility_is_grayscale_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_grayscale_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is grayscale enabled - True","feature_key":"accessibility_is_grayscale_enabled","property_key":"true","platform":"ios","amount":4675,"percentage":0.07}
+{"name":"Ios - Accessibility is grayscale enabled - True","feature_key":"accessibility_is_grayscale_enabled","property_key":"true","platform":"ios","amount":4676,"percentage":0.07}

--- a/src/data/generated/data-features/ios-accessibility_is_grayscale_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_grayscale_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is grayscale enabled - True","feature_key":"accessibility_is_grayscale_enabled","property_key":"true","platform":"ios","amount":4676,"percentage":0.07}
+{"name":"Ios - Accessibility is grayscale enabled - True","feature_key":"accessibility_is_grayscale_enabled","property_key":"true","platform":"ios","amount":4680,"percentage":0.07}

--- a/src/data/generated/data-features/ios-accessibility_is_grayscale_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_grayscale_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is grayscale enabled - True","feature_key":"accessibility_is_grayscale_enabled","property_key":"true","platform":"ios","amount":4672,"percentage":0.07}
+{"name":"Ios - Accessibility is grayscale enabled - True","feature_key":"accessibility_is_grayscale_enabled","property_key":"true","platform":"ios","amount":4675,"percentage":0.07}

--- a/src/data/generated/data-features/ios-accessibility_is_guided_access_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_guided_access_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is guided access enabled - False","feature_key":"accessibility_is_guided_access_enabled","property_key":"false","platform":"ios","amount":6269046,"percentage":100}
+{"name":"Ios - Accessibility is guided access enabled - False","feature_key":"accessibility_is_guided_access_enabled","property_key":"false","platform":"ios","amount":6269837,"percentage":100}

--- a/src/data/generated/data-features/ios-accessibility_is_guided_access_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_guided_access_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is guided access enabled - False","feature_key":"accessibility_is_guided_access_enabled","property_key":"false","platform":"ios","amount":6268585,"percentage":100}
+{"name":"Ios - Accessibility is guided access enabled - False","feature_key":"accessibility_is_guided_access_enabled","property_key":"false","platform":"ios","amount":6269046,"percentage":100}

--- a/src/data/generated/data-features/ios-accessibility_is_guided_access_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_guided_access_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is guided access enabled - False","feature_key":"accessibility_is_guided_access_enabled","property_key":"false","platform":"ios","amount":6269837,"percentage":100}
+{"name":"Ios - Accessibility is guided access enabled - False","feature_key":"accessibility_is_guided_access_enabled","property_key":"false","platform":"ios","amount":6270636,"percentage":100}

--- a/src/data/generated/data-features/ios-accessibility_is_guided_access_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_guided_access_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is guided access enabled - False","feature_key":"accessibility_is_guided_access_enabled","property_key":"false","platform":"ios","amount":6270636,"percentage":100}
+{"name":"Ios - Accessibility is guided access enabled - False","feature_key":"accessibility_is_guided_access_enabled","property_key":"false","platform":"ios","amount":6271437,"percentage":100}

--- a/src/data/generated/data-features/ios-accessibility_is_invert_colors_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_invert_colors_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is invert colors enabled - False","feature_key":"accessibility_is_invert_colors_enabled","property_key":"false","platform":"ios","amount":6268405,"percentage":99.99}
+{"name":"Ios - Accessibility is invert colors enabled - False","feature_key":"accessibility_is_invert_colors_enabled","property_key":"false","platform":"ios","amount":6269197,"percentage":99.99}

--- a/src/data/generated/data-features/ios-accessibility_is_invert_colors_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_invert_colors_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is invert colors enabled - False","feature_key":"accessibility_is_invert_colors_enabled","property_key":"false","platform":"ios","amount":6269197,"percentage":99.99}
+{"name":"Ios - Accessibility is invert colors enabled - False","feature_key":"accessibility_is_invert_colors_enabled","property_key":"false","platform":"ios","amount":6269996,"percentage":99.99}

--- a/src/data/generated/data-features/ios-accessibility_is_invert_colors_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_invert_colors_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is invert colors enabled - False","feature_key":"accessibility_is_invert_colors_enabled","property_key":"false","platform":"ios","amount":6269996,"percentage":99.99}
+{"name":"Ios - Accessibility is invert colors enabled - False","feature_key":"accessibility_is_invert_colors_enabled","property_key":"false","platform":"ios","amount":6270799,"percentage":99.99}

--- a/src/data/generated/data-features/ios-accessibility_is_invert_colors_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_invert_colors_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is invert colors enabled - False","feature_key":"accessibility_is_invert_colors_enabled","property_key":"false","platform":"ios","amount":6267945,"percentage":99.99}
+{"name":"Ios - Accessibility is invert colors enabled - False","feature_key":"accessibility_is_invert_colors_enabled","property_key":"false","platform":"ios","amount":6268405,"percentage":99.99}

--- a/src/data/generated/data-features/ios-accessibility_is_invert_colors_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_invert_colors_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is invert colors enabled - True","feature_key":"accessibility_is_invert_colors_enabled","property_key":"true","platform":"ios","amount":641,"percentage":0.01}
+{"name":"Ios - Accessibility is invert colors enabled - True","feature_key":"accessibility_is_invert_colors_enabled","property_key":"true","platform":"ios","amount":640,"percentage":0.01}

--- a/src/data/generated/data-features/ios-accessibility_is_invert_colors_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_invert_colors_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is invert colors enabled - True","feature_key":"accessibility_is_invert_colors_enabled","property_key":"true","platform":"ios","amount":640,"percentage":0.01}
+{"name":"Ios - Accessibility is invert colors enabled - True","feature_key":"accessibility_is_invert_colors_enabled","property_key":"true","platform":"ios","amount":638,"percentage":0.01}

--- a/src/data/generated/data-features/ios-accessibility_is_invert_colors_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_invert_colors_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is invert colors enabled - True","feature_key":"accessibility_is_invert_colors_enabled","property_key":"true","platform":"ios","amount":640,"percentage":0.01}
+{"name":"Ios - Accessibility is invert colors enabled - True","feature_key":"accessibility_is_invert_colors_enabled","property_key":"true","platform":"ios","amount":641,"percentage":0.01}

--- a/src/data/generated/data-features/ios-accessibility_is_mono_audio_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_mono_audio_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is mono audio enabled - False","feature_key":"accessibility_is_mono_audio_enabled","property_key":"false","platform":"ios","amount":6027734,"percentage":96.36}
+{"name":"Ios - Accessibility is mono audio enabled - False","feature_key":"accessibility_is_mono_audio_enabled","property_key":"false","platform":"ios","amount":6028495,"percentage":96.36}

--- a/src/data/generated/data-features/ios-accessibility_is_mono_audio_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_mono_audio_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is mono audio enabled - False","feature_key":"accessibility_is_mono_audio_enabled","property_key":"false","platform":"ios","amount":6029246,"percentage":96.36}
+{"name":"Ios - Accessibility is mono audio enabled - False","feature_key":"accessibility_is_mono_audio_enabled","property_key":"false","platform":"ios","amount":6030000,"percentage":96.36}

--- a/src/data/generated/data-features/ios-accessibility_is_mono_audio_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_mono_audio_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is mono audio enabled - False","feature_key":"accessibility_is_mono_audio_enabled","property_key":"false","platform":"ios","amount":6028495,"percentage":96.36}
+{"name":"Ios - Accessibility is mono audio enabled - False","feature_key":"accessibility_is_mono_audio_enabled","property_key":"false","platform":"ios","amount":6029246,"percentage":96.36}

--- a/src/data/generated/data-features/ios-accessibility_is_mono_audio_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_mono_audio_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is mono audio enabled - False","feature_key":"accessibility_is_mono_audio_enabled","property_key":"false","platform":"ios","amount":6027291,"percentage":96.36}
+{"name":"Ios - Accessibility is mono audio enabled - False","feature_key":"accessibility_is_mono_audio_enabled","property_key":"false","platform":"ios","amount":6027734,"percentage":96.36}

--- a/src/data/generated/data-features/ios-accessibility_is_mono_audio_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_mono_audio_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is mono audio enabled - True","feature_key":"accessibility_is_mono_audio_enabled","property_key":"true","platform":"ios","amount":241390,"percentage":3.64}
+{"name":"Ios - Accessibility is mono audio enabled - True","feature_key":"accessibility_is_mono_audio_enabled","property_key":"true","platform":"ios","amount":241437,"percentage":3.64}

--- a/src/data/generated/data-features/ios-accessibility_is_mono_audio_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_mono_audio_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is mono audio enabled - True","feature_key":"accessibility_is_mono_audio_enabled","property_key":"true","platform":"ios","amount":241312,"percentage":3.64}
+{"name":"Ios - Accessibility is mono audio enabled - True","feature_key":"accessibility_is_mono_audio_enabled","property_key":"true","platform":"ios","amount":241342,"percentage":3.64}

--- a/src/data/generated/data-features/ios-accessibility_is_mono_audio_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_mono_audio_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is mono audio enabled - True","feature_key":"accessibility_is_mono_audio_enabled","property_key":"true","platform":"ios","amount":241294,"percentage":3.64}
+{"name":"Ios - Accessibility is mono audio enabled - True","feature_key":"accessibility_is_mono_audio_enabled","property_key":"true","platform":"ios","amount":241312,"percentage":3.64}

--- a/src/data/generated/data-features/ios-accessibility_is_mono_audio_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_mono_audio_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is mono audio enabled - True","feature_key":"accessibility_is_mono_audio_enabled","property_key":"true","platform":"ios","amount":241342,"percentage":3.64}
+{"name":"Ios - Accessibility is mono audio enabled - True","feature_key":"accessibility_is_mono_audio_enabled","property_key":"true","platform":"ios","amount":241390,"percentage":3.64}

--- a/src/data/generated/data-features/ios-accessibility_is_reduce_transparency_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_reduce_transparency_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is reduce transparency enabled - False","feature_key":"accessibility_is_reduce_transparency_enabled","property_key":"false","platform":"ios","amount":6052767,"percentage":96.68}
+{"name":"Ios - Accessibility is reduce transparency enabled - False","feature_key":"accessibility_is_reduce_transparency_enabled","property_key":"false","platform":"ios","amount":6053536,"percentage":96.68}

--- a/src/data/generated/data-features/ios-accessibility_is_reduce_transparency_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_reduce_transparency_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is reduce transparency enabled - False","feature_key":"accessibility_is_reduce_transparency_enabled","property_key":"false","platform":"ios","amount":6051999,"percentage":96.68}
+{"name":"Ios - Accessibility is reduce transparency enabled - False","feature_key":"accessibility_is_reduce_transparency_enabled","property_key":"false","platform":"ios","amount":6052767,"percentage":96.68}

--- a/src/data/generated/data-features/ios-accessibility_is_reduce_transparency_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_reduce_transparency_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is reduce transparency enabled - False","feature_key":"accessibility_is_reduce_transparency_enabled","property_key":"false","platform":"ios","amount":6051552,"percentage":96.68}
+{"name":"Ios - Accessibility is reduce transparency enabled - False","feature_key":"accessibility_is_reduce_transparency_enabled","property_key":"false","platform":"ios","amount":6051999,"percentage":96.68}

--- a/src/data/generated/data-features/ios-accessibility_is_reduce_transparency_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_reduce_transparency_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is reduce transparency enabled - False","feature_key":"accessibility_is_reduce_transparency_enabled","property_key":"false","platform":"ios","amount":6053536,"percentage":96.68}
+{"name":"Ios - Accessibility is reduce transparency enabled - False","feature_key":"accessibility_is_reduce_transparency_enabled","property_key":"false","platform":"ios","amount":6054300,"percentage":96.68}

--- a/src/data/generated/data-features/ios-accessibility_is_reduce_transparency_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_reduce_transparency_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is reduce transparency enabled - True","feature_key":"accessibility_is_reduce_transparency_enabled","property_key":"true","platform":"ios","amount":217047,"percentage":3.32}
+{"name":"Ios - Accessibility is reduce transparency enabled - True","feature_key":"accessibility_is_reduce_transparency_enabled","property_key":"true","platform":"ios","amount":217070,"percentage":3.32}

--- a/src/data/generated/data-features/ios-accessibility_is_reduce_transparency_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_reduce_transparency_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is reduce transparency enabled - True","feature_key":"accessibility_is_reduce_transparency_enabled","property_key":"true","platform":"ios","amount":217070,"percentage":3.32}
+{"name":"Ios - Accessibility is reduce transparency enabled - True","feature_key":"accessibility_is_reduce_transparency_enabled","property_key":"true","platform":"ios","amount":217100,"percentage":3.32}

--- a/src/data/generated/data-features/ios-accessibility_is_reduce_transparency_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_reduce_transparency_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is reduce transparency enabled - True","feature_key":"accessibility_is_reduce_transparency_enabled","property_key":"true","platform":"ios","amount":217100,"percentage":3.32}
+{"name":"Ios - Accessibility is reduce transparency enabled - True","feature_key":"accessibility_is_reduce_transparency_enabled","property_key":"true","platform":"ios","amount":217137,"percentage":3.32}

--- a/src/data/generated/data-features/ios-accessibility_is_reduce_transparency_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_reduce_transparency_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is reduce transparency enabled - True","feature_key":"accessibility_is_reduce_transparency_enabled","property_key":"true","platform":"ios","amount":217033,"percentage":3.32}
+{"name":"Ios - Accessibility is reduce transparency enabled - True","feature_key":"accessibility_is_reduce_transparency_enabled","property_key":"true","platform":"ios","amount":217047,"percentage":3.32}

--- a/src/data/generated/data-features/ios-accessibility_is_shake_to_undo_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_shake_to_undo_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is shake to undo enabled - False","feature_key":"accessibility_is_shake_to_undo_enabled","property_key":"false","platform":"ios","amount":408180,"percentage":6.16}
+{"name":"Ios - Accessibility is shake to undo enabled - False","feature_key":"accessibility_is_shake_to_undo_enabled","property_key":"false","platform":"ios","amount":408197,"percentage":6.16}

--- a/src/data/generated/data-features/ios-accessibility_is_shake_to_undo_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_shake_to_undo_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is shake to undo enabled - False","feature_key":"accessibility_is_shake_to_undo_enabled","property_key":"false","platform":"ios","amount":408291,"percentage":6.16}
+{"name":"Ios - Accessibility is shake to undo enabled - False","feature_key":"accessibility_is_shake_to_undo_enabled","property_key":"false","platform":"ios","amount":408328,"percentage":6.16}

--- a/src/data/generated/data-features/ios-accessibility_is_shake_to_undo_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_shake_to_undo_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is shake to undo enabled - False","feature_key":"accessibility_is_shake_to_undo_enabled","property_key":"false","platform":"ios","amount":408243,"percentage":6.16}
+{"name":"Ios - Accessibility is shake to undo enabled - False","feature_key":"accessibility_is_shake_to_undo_enabled","property_key":"false","platform":"ios","amount":408291,"percentage":6.16}

--- a/src/data/generated/data-features/ios-accessibility_is_shake_to_undo_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_shake_to_undo_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is shake to undo enabled - False","feature_key":"accessibility_is_shake_to_undo_enabled","property_key":"false","platform":"ios","amount":408197,"percentage":6.16}
+{"name":"Ios - Accessibility is shake to undo enabled - False","feature_key":"accessibility_is_shake_to_undo_enabled","property_key":"false","platform":"ios","amount":408243,"percentage":6.16}

--- a/src/data/generated/data-features/ios-accessibility_is_shake_to_undo_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_shake_to_undo_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is shake to undo enabled - True","feature_key":"accessibility_is_shake_to_undo_enabled","property_key":"true","platform":"ios","amount":5861594,"percentage":93.84}
+{"name":"Ios - Accessibility is shake to undo enabled - True","feature_key":"accessibility_is_shake_to_undo_enabled","property_key":"true","platform":"ios","amount":5862345,"percentage":93.84}

--- a/src/data/generated/data-features/ios-accessibility_is_shake_to_undo_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_shake_to_undo_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is shake to undo enabled - True","feature_key":"accessibility_is_shake_to_undo_enabled","property_key":"true","platform":"ios","amount":5860849,"percentage":93.84}
+{"name":"Ios - Accessibility is shake to undo enabled - True","feature_key":"accessibility_is_shake_to_undo_enabled","property_key":"true","platform":"ios","amount":5861594,"percentage":93.84}

--- a/src/data/generated/data-features/ios-accessibility_is_shake_to_undo_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_shake_to_undo_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is shake to undo enabled - True","feature_key":"accessibility_is_shake_to_undo_enabled","property_key":"true","platform":"ios","amount":5862345,"percentage":93.84}
+{"name":"Ios - Accessibility is shake to undo enabled - True","feature_key":"accessibility_is_shake_to_undo_enabled","property_key":"true","platform":"ios","amount":5863109,"percentage":93.84}

--- a/src/data/generated/data-features/ios-accessibility_is_shake_to_undo_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_shake_to_undo_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is shake to undo enabled - True","feature_key":"accessibility_is_shake_to_undo_enabled","property_key":"true","platform":"ios","amount":5860405,"percentage":93.84}
+{"name":"Ios - Accessibility is shake to undo enabled - True","feature_key":"accessibility_is_shake_to_undo_enabled","property_key":"true","platform":"ios","amount":5860849,"percentage":93.84}

--- a/src/data/generated/data-features/ios-accessibility_is_speak_screen_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_speak_screen_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is speak screen enabled - False","feature_key":"accessibility_is_speak_screen_enabled","property_key":"false","platform":"ios","amount":6112108,"percentage":97.69}
+{"name":"Ios - Accessibility is speak screen enabled - False","feature_key":"accessibility_is_speak_screen_enabled","property_key":"false","platform":"ios","amount":6112562,"percentage":97.69}

--- a/src/data/generated/data-features/ios-accessibility_is_speak_screen_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_speak_screen_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is speak screen enabled - False","feature_key":"accessibility_is_speak_screen_enabled","property_key":"false","platform":"ios","amount":6112562,"percentage":97.69}
+{"name":"Ios - Accessibility is speak screen enabled - False","feature_key":"accessibility_is_speak_screen_enabled","property_key":"false","platform":"ios","amount":6113332,"percentage":97.69}

--- a/src/data/generated/data-features/ios-accessibility_is_speak_screen_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_speak_screen_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is speak screen enabled - False","feature_key":"accessibility_is_speak_screen_enabled","property_key":"false","platform":"ios","amount":6113332,"percentage":97.69}
+{"name":"Ios - Accessibility is speak screen enabled - False","feature_key":"accessibility_is_speak_screen_enabled","property_key":"false","platform":"ios","amount":6114112,"percentage":97.69}

--- a/src/data/generated/data-features/ios-accessibility_is_speak_screen_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_speak_screen_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is speak screen enabled - False","feature_key":"accessibility_is_speak_screen_enabled","property_key":"false","platform":"ios","amount":6114112,"percentage":97.69}
+{"name":"Ios - Accessibility is speak screen enabled - False","feature_key":"accessibility_is_speak_screen_enabled","property_key":"false","platform":"ios","amount":6114896,"percentage":97.69}

--- a/src/data/generated/data-features/ios-accessibility_is_speak_screen_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_speak_screen_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is speak screen enabled - True","feature_key":"accessibility_is_speak_screen_enabled","property_key":"true","platform":"ios","amount":156484,"percentage":2.31}
+{"name":"Ios - Accessibility is speak screen enabled - True","feature_key":"accessibility_is_speak_screen_enabled","property_key":"true","platform":"ios","amount":156505,"percentage":2.31}

--- a/src/data/generated/data-features/ios-accessibility_is_speak_screen_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_speak_screen_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is speak screen enabled - True","feature_key":"accessibility_is_speak_screen_enabled","property_key":"true","platform":"ios","amount":156477,"percentage":2.31}
+{"name":"Ios - Accessibility is speak screen enabled - True","feature_key":"accessibility_is_speak_screen_enabled","property_key":"true","platform":"ios","amount":156484,"percentage":2.31}

--- a/src/data/generated/data-features/ios-accessibility_is_speak_screen_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_speak_screen_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is speak screen enabled - True","feature_key":"accessibility_is_speak_screen_enabled","property_key":"true","platform":"ios","amount":156524,"percentage":2.31}
+{"name":"Ios - Accessibility is speak screen enabled - True","feature_key":"accessibility_is_speak_screen_enabled","property_key":"true","platform":"ios","amount":156541,"percentage":2.31}

--- a/src/data/generated/data-features/ios-accessibility_is_speak_screen_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_speak_screen_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is speak screen enabled - True","feature_key":"accessibility_is_speak_screen_enabled","property_key":"true","platform":"ios","amount":156505,"percentage":2.31}
+{"name":"Ios - Accessibility is speak screen enabled - True","feature_key":"accessibility_is_speak_screen_enabled","property_key":"true","platform":"ios","amount":156524,"percentage":2.31}

--- a/src/data/generated/data-features/ios-accessibility_is_speak_selection_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_speak_selection_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is speak selection enabled - False","feature_key":"accessibility_is_speak_selection_enabled","property_key":"false","platform":"ios","amount":6032184,"percentage":96.45}
+{"name":"Ios - Accessibility is speak selection enabled - False","feature_key":"accessibility_is_speak_selection_enabled","property_key":"false","platform":"ios","amount":6032639,"percentage":96.45}

--- a/src/data/generated/data-features/ios-accessibility_is_speak_selection_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_speak_selection_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is speak selection enabled - False","feature_key":"accessibility_is_speak_selection_enabled","property_key":"false","platform":"ios","amount":6032639,"percentage":96.45}
+{"name":"Ios - Accessibility is speak selection enabled - False","feature_key":"accessibility_is_speak_selection_enabled","property_key":"false","platform":"ios","amount":6033404,"percentage":96.45}

--- a/src/data/generated/data-features/ios-accessibility_is_speak_selection_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_speak_selection_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is speak selection enabled - False","feature_key":"accessibility_is_speak_selection_enabled","property_key":"false","platform":"ios","amount":6033404,"percentage":96.45}
+{"name":"Ios - Accessibility is speak selection enabled - False","feature_key":"accessibility_is_speak_selection_enabled","property_key":"false","platform":"ios","amount":6034177,"percentage":96.45}

--- a/src/data/generated/data-features/ios-accessibility_is_speak_selection_enabled-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_speak_selection_enabled-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is speak selection enabled - False","feature_key":"accessibility_is_speak_selection_enabled","property_key":"false","platform":"ios","amount":6034177,"percentage":96.45}
+{"name":"Ios - Accessibility is speak selection enabled - False","feature_key":"accessibility_is_speak_selection_enabled","property_key":"false","platform":"ios","amount":6034959,"percentage":96.45}

--- a/src/data/generated/data-features/ios-accessibility_is_speak_selection_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_speak_selection_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is speak selection enabled - True","feature_key":"accessibility_is_speak_selection_enabled","property_key":"true","platform":"ios","amount":236407,"percentage":3.55}
+{"name":"Ios - Accessibility is speak selection enabled - True","feature_key":"accessibility_is_speak_selection_enabled","property_key":"true","platform":"ios","amount":236433,"percentage":3.55}

--- a/src/data/generated/data-features/ios-accessibility_is_speak_selection_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_speak_selection_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is speak selection enabled - True","feature_key":"accessibility_is_speak_selection_enabled","property_key":"true","platform":"ios","amount":236401,"percentage":3.55}
+{"name":"Ios - Accessibility is speak selection enabled - True","feature_key":"accessibility_is_speak_selection_enabled","property_key":"true","platform":"ios","amount":236407,"percentage":3.55}

--- a/src/data/generated/data-features/ios-accessibility_is_speak_selection_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_speak_selection_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is speak selection enabled - True","feature_key":"accessibility_is_speak_selection_enabled","property_key":"true","platform":"ios","amount":236459,"percentage":3.55}
+{"name":"Ios - Accessibility is speak selection enabled - True","feature_key":"accessibility_is_speak_selection_enabled","property_key":"true","platform":"ios","amount":236478,"percentage":3.55}

--- a/src/data/generated/data-features/ios-accessibility_is_speak_selection_enabled-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_speak_selection_enabled-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is speak selection enabled - True","feature_key":"accessibility_is_speak_selection_enabled","property_key":"true","platform":"ios","amount":236433,"percentage":3.55}
+{"name":"Ios - Accessibility is speak selection enabled - True","feature_key":"accessibility_is_speak_selection_enabled","property_key":"true","platform":"ios","amount":236459,"percentage":3.55}

--- a/src/data/generated/data-features/ios-accessibility_is_switch_control_running-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_switch_control_running-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is switch control running - False","feature_key":"accessibility_is_switch_control_running","property_key":"false","platform":"ios","amount":6268835,"percentage":100}
+{"name":"Ios - Accessibility is switch control running - False","feature_key":"accessibility_is_switch_control_running","property_key":"false","platform":"ios","amount":6269626,"percentage":100}

--- a/src/data/generated/data-features/ios-accessibility_is_switch_control_running-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_switch_control_running-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is switch control running - False","feature_key":"accessibility_is_switch_control_running","property_key":"false","platform":"ios","amount":6270424,"percentage":100}
+{"name":"Ios - Accessibility is switch control running - False","feature_key":"accessibility_is_switch_control_running","property_key":"false","platform":"ios","amount":6271225,"percentage":100}

--- a/src/data/generated/data-features/ios-accessibility_is_switch_control_running-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_switch_control_running-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is switch control running - False","feature_key":"accessibility_is_switch_control_running","property_key":"false","platform":"ios","amount":6269626,"percentage":100}
+{"name":"Ios - Accessibility is switch control running - False","feature_key":"accessibility_is_switch_control_running","property_key":"false","platform":"ios","amount":6270424,"percentage":100}

--- a/src/data/generated/data-features/ios-accessibility_is_switch_control_running-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_switch_control_running-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is switch control running - False","feature_key":"accessibility_is_switch_control_running","property_key":"false","platform":"ios","amount":6268374,"percentage":100}
+{"name":"Ios - Accessibility is switch control running - False","feature_key":"accessibility_is_switch_control_running","property_key":"false","platform":"ios","amount":6268835,"percentage":100}

--- a/src/data/generated/data-features/ios-accessibility_is_switch_control_running-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_switch_control_running-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is switch control running - True","feature_key":"accessibility_is_switch_control_running","property_key":"true","platform":"ios","amount":211,"percentage":0}
+{"name":"Ios - Accessibility is switch control running - True","feature_key":"accessibility_is_switch_control_running","property_key":"true","platform":"ios","amount":212,"percentage":0}

--- a/src/data/generated/data-features/ios-accessibility_is_voice_over_running-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_voice_over_running-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is voice over running - False","feature_key":"accessibility_is_voice_over_running","property_key":"false","platform":"ios","amount":6269421,"percentage":99.98}
+{"name":"Ios - Accessibility is voice over running - False","feature_key":"accessibility_is_voice_over_running","property_key":"false","platform":"ios","amount":6270221,"percentage":99.98}

--- a/src/data/generated/data-features/ios-accessibility_is_voice_over_running-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_voice_over_running-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is voice over running - False","feature_key":"accessibility_is_voice_over_running","property_key":"false","platform":"ios","amount":6267369,"percentage":99.98}
+{"name":"Ios - Accessibility is voice over running - False","feature_key":"accessibility_is_voice_over_running","property_key":"false","platform":"ios","amount":6267832,"percentage":99.98}

--- a/src/data/generated/data-features/ios-accessibility_is_voice_over_running-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_voice_over_running-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is voice over running - False","feature_key":"accessibility_is_voice_over_running","property_key":"false","platform":"ios","amount":6267832,"percentage":99.98}
+{"name":"Ios - Accessibility is voice over running - False","feature_key":"accessibility_is_voice_over_running","property_key":"false","platform":"ios","amount":6268623,"percentage":99.98}

--- a/src/data/generated/data-features/ios-accessibility_is_voice_over_running-false.json
+++ b/src/data/generated/data-features/ios-accessibility_is_voice_over_running-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is voice over running - False","feature_key":"accessibility_is_voice_over_running","property_key":"false","platform":"ios","amount":6268623,"percentage":99.98}
+{"name":"Ios - Accessibility is voice over running - False","feature_key":"accessibility_is_voice_over_running","property_key":"false","platform":"ios","amount":6269421,"percentage":99.98}

--- a/src/data/generated/data-features/ios-accessibility_is_voice_over_running-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_voice_over_running-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is voice over running - True","feature_key":"accessibility_is_voice_over_running","property_key":"true","platform":"ios","amount":1214,"percentage":0.02}
+{"name":"Ios - Accessibility is voice over running - True","feature_key":"accessibility_is_voice_over_running","property_key":"true","platform":"ios","amount":1215,"percentage":0.02}

--- a/src/data/generated/data-features/ios-accessibility_is_voice_over_running-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_voice_over_running-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is voice over running - True","feature_key":"accessibility_is_voice_over_running","property_key":"true","platform":"ios","amount":1215,"percentage":0.02}
+{"name":"Ios - Accessibility is voice over running - True","feature_key":"accessibility_is_voice_over_running","property_key":"true","platform":"ios","amount":1216,"percentage":0.02}

--- a/src/data/generated/data-features/ios-accessibility_is_voice_over_running-true.json
+++ b/src/data/generated/data-features/ios-accessibility_is_voice_over_running-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Accessibility is voice over running - True","feature_key":"accessibility_is_voice_over_running","property_key":"true","platform":"ios","amount":1216,"percentage":0.02}
+{"name":"Ios - Accessibility is voice over running - True","feature_key":"accessibility_is_voice_over_running","property_key":"true","platform":"ios","amount":1214,"percentage":0.02}

--- a/src/data/generated/data-features/ios-custom_content_size-default.json
+++ b/src/data/generated/data-features/ios-custom_content_size-default.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Custom content size - Default","feature_key":"custom_content_size","property_key":"default","platform":"ios","amount":4024104,"percentage":64.14}
+{"name":"Ios - Custom content size - Default","feature_key":"custom_content_size","property_key":"default","platform":"ios","amount":4024640,"percentage":64.15}

--- a/src/data/generated/data-features/ios-custom_content_size-default.json
+++ b/src/data/generated/data-features/ios-custom_content_size-default.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Custom content size - Default","feature_key":"custom_content_size","property_key":"default","platform":"ios","amount":4023251,"percentage":64.14}
+{"name":"Ios - Custom content size - Default","feature_key":"custom_content_size","property_key":"default","platform":"ios","amount":4023569,"percentage":64.14}

--- a/src/data/generated/data-features/ios-custom_content_size-default.json
+++ b/src/data/generated/data-features/ios-custom_content_size-default.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Custom content size - Default","feature_key":"custom_content_size","property_key":"default","platform":"ios","amount":4023569,"percentage":64.14}
+{"name":"Ios - Custom content size - Default","feature_key":"custom_content_size","property_key":"default","platform":"ios","amount":4024104,"percentage":64.14}

--- a/src/data/generated/data-features/ios-custom_content_size-default.json
+++ b/src/data/generated/data-features/ios-custom_content_size-default.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Custom content size - Default","feature_key":"custom_content_size","property_key":"default","platform":"ios","amount":4024640,"percentage":64.15}
+{"name":"Ios - Custom content size - Default","feature_key":"custom_content_size","property_key":"default","platform":"ios","amount":4025146,"percentage":64.15}

--- a/src/data/generated/data-features/ios-custom_content_size-larger.json
+++ b/src/data/generated/data-features/ios-custom_content_size-larger.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Custom content size - Larger","feature_key":"custom_content_size","property_key":"larger","platform":"ios","amount":1485030,"percentage":24.36}
+{"name":"Ios - Custom content size - Larger","feature_key":"custom_content_size","property_key":"larger","platform":"ios","amount":1485245,"percentage":24.36}

--- a/src/data/generated/data-features/ios-custom_content_size-larger.json
+++ b/src/data/generated/data-features/ios-custom_content_size-larger.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Custom content size - Larger","feature_key":"custom_content_size","property_key":"larger","platform":"ios","amount":1484560,"percentage":24.36}
+{"name":"Ios - Custom content size - Larger","feature_key":"custom_content_size","property_key":"larger","platform":"ios","amount":1484661,"percentage":24.36}

--- a/src/data/generated/data-features/ios-custom_content_size-larger.json
+++ b/src/data/generated/data-features/ios-custom_content_size-larger.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Custom content size - Larger","feature_key":"custom_content_size","property_key":"larger","platform":"ios","amount":1484661,"percentage":24.36}
+{"name":"Ios - Custom content size - Larger","feature_key":"custom_content_size","property_key":"larger","platform":"ios","amount":1484843,"percentage":24.36}

--- a/src/data/generated/data-features/ios-custom_content_size-larger.json
+++ b/src/data/generated/data-features/ios-custom_content_size-larger.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Custom content size - Larger","feature_key":"custom_content_size","property_key":"larger","platform":"ios","amount":1484843,"percentage":24.36}
+{"name":"Ios - Custom content size - Larger","feature_key":"custom_content_size","property_key":"larger","platform":"ios","amount":1485030,"percentage":24.36}

--- a/src/data/generated/data-features/ios-custom_content_size-smaller.json
+++ b/src/data/generated/data-features/ios-custom_content_size-smaller.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Custom content size - Smaller","feature_key":"custom_content_size","property_key":"smaller","platform":"ios","amount":760890,"percentage":11.48}
+{"name":"Ios - Custom content size - Smaller","feature_key":"custom_content_size","property_key":"smaller","platform":"ios","amount":760966,"percentage":11.48}

--- a/src/data/generated/data-features/ios-custom_content_size-smaller.json
+++ b/src/data/generated/data-features/ios-custom_content_size-smaller.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Custom content size - Smaller","feature_key":"custom_content_size","property_key":"smaller","platform":"ios","amount":760774,"percentage":11.48}
+{"name":"Ios - Custom content size - Smaller","feature_key":"custom_content_size","property_key":"smaller","platform":"ios","amount":760816,"percentage":11.48}

--- a/src/data/generated/data-features/ios-custom_content_size-smaller.json
+++ b/src/data/generated/data-features/ios-custom_content_size-smaller.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Custom content size - Smaller","feature_key":"custom_content_size","property_key":"smaller","platform":"ios","amount":760966,"percentage":11.48}
+{"name":"Ios - Custom content size - Smaller","feature_key":"custom_content_size","property_key":"smaller","platform":"ios","amount":761046,"percentage":11.48}

--- a/src/data/generated/data-features/ios-custom_content_size-smaller.json
+++ b/src/data/generated/data-features/ios-custom_content_size-smaller.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Custom content size - Smaller","feature_key":"custom_content_size","property_key":"smaller","platform":"ios","amount":760816,"percentage":11.48}
+{"name":"Ios - Custom content size - Smaller","feature_key":"custom_content_size","property_key":"smaller","platform":"ios","amount":760890,"percentage":11.48}

--- a/src/data/generated/data-features/ios-non_default_content_size-false.json
+++ b/src/data/generated/data-features/ios-non_default_content_size-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Non default content size - False","feature_key":"non_default_content_size","property_key":"false","platform":"ios","amount":4023251,"percentage":64.14}
+{"name":"Ios - Non default content size - False","feature_key":"non_default_content_size","property_key":"false","platform":"ios","amount":4023569,"percentage":64.14}

--- a/src/data/generated/data-features/ios-non_default_content_size-false.json
+++ b/src/data/generated/data-features/ios-non_default_content_size-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Non default content size - False","feature_key":"non_default_content_size","property_key":"false","platform":"ios","amount":4024640,"percentage":64.15}
+{"name":"Ios - Non default content size - False","feature_key":"non_default_content_size","property_key":"false","platform":"ios","amount":4025146,"percentage":64.15}

--- a/src/data/generated/data-features/ios-non_default_content_size-false.json
+++ b/src/data/generated/data-features/ios-non_default_content_size-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Non default content size - False","feature_key":"non_default_content_size","property_key":"false","platform":"ios","amount":4023569,"percentage":64.14}
+{"name":"Ios - Non default content size - False","feature_key":"non_default_content_size","property_key":"false","platform":"ios","amount":4024104,"percentage":64.14}

--- a/src/data/generated/data-features/ios-non_default_content_size-false.json
+++ b/src/data/generated/data-features/ios-non_default_content_size-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Non default content size - False","feature_key":"non_default_content_size","property_key":"false","platform":"ios","amount":4024104,"percentage":64.14}
+{"name":"Ios - Non default content size - False","feature_key":"non_default_content_size","property_key":"false","platform":"ios","amount":4024640,"percentage":64.15}

--- a/src/data/generated/data-features/ios-non_default_content_size-true.json
+++ b/src/data/generated/data-features/ios-non_default_content_size-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Non default content size - True","feature_key":"non_default_content_size","property_key":"true","platform":"ios","amount":2245733,"percentage":35.84}
+{"name":"Ios - Non default content size - True","feature_key":"non_default_content_size","property_key":"true","platform":"ios","amount":2245996,"percentage":35.84}

--- a/src/data/generated/data-features/ios-non_default_content_size-true.json
+++ b/src/data/generated/data-features/ios-non_default_content_size-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Non default content size - True","feature_key":"non_default_content_size","property_key":"true","platform":"ios","amount":2245477,"percentage":35.84}
+{"name":"Ios - Non default content size - True","feature_key":"non_default_content_size","property_key":"true","platform":"ios","amount":2245733,"percentage":35.84}

--- a/src/data/generated/data-features/ios-non_default_content_size-true.json
+++ b/src/data/generated/data-features/ios-non_default_content_size-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Non default content size - True","feature_key":"non_default_content_size","property_key":"true","platform":"ios","amount":2245996,"percentage":35.84}
+{"name":"Ios - Non default content size - True","feature_key":"non_default_content_size","property_key":"true","platform":"ios","amount":2246291,"percentage":35.84}

--- a/src/data/generated/data-features/ios-non_default_content_size-true.json
+++ b/src/data/generated/data-features/ios-non_default_content_size-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Non default content size - True","feature_key":"non_default_content_size","property_key":"true","platform":"ios","amount":2245334,"percentage":35.84}
+{"name":"Ios - Non default content size - True","feature_key":"non_default_content_size","property_key":"true","platform":"ios","amount":2245477,"percentage":35.84}

--- a/src/data/generated/data-features/ios-preference_daytime-day.json
+++ b/src/data/generated/data-features/ios-preference_daytime-day.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Preference daytime - Day","feature_key":"preference_daytime","property_key":"day","platform":"ios","amount":3841253,"percentage":60.44}
+{"name":"Ios - Preference daytime - Day","feature_key":"preference_daytime","property_key":"day","platform":"ios","amount":3839032,"percentage":60.4}

--- a/src/data/generated/data-features/ios-preference_daytime-day.json
+++ b/src/data/generated/data-features/ios-preference_daytime-day.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Preference daytime - Day","feature_key":"preference_daytime","property_key":"day","platform":"ios","amount":3844418,"percentage":60.5}
+{"name":"Ios - Preference daytime - Day","feature_key":"preference_daytime","property_key":"day","platform":"ios","amount":3843027,"percentage":60.48}

--- a/src/data/generated/data-features/ios-preference_daytime-day.json
+++ b/src/data/generated/data-features/ios-preference_daytime-day.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Preference daytime - Day","feature_key":"preference_daytime","property_key":"day","platform":"ios","amount":3839032,"percentage":60.4}
+{"name":"Ios - Preference daytime - Day","feature_key":"preference_daytime","property_key":"day","platform":"ios","amount":3837182,"percentage":60.37}

--- a/src/data/generated/data-features/ios-preference_daytime-day.json
+++ b/src/data/generated/data-features/ios-preference_daytime-day.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Preference daytime - Day","feature_key":"preference_daytime","property_key":"day","platform":"ios","amount":3843027,"percentage":60.48}
+{"name":"Ios - Preference daytime - Day","feature_key":"preference_daytime","property_key":"day","platform":"ios","amount":3841253,"percentage":60.44}

--- a/src/data/generated/data-features/ios-preference_daytime-night.json
+++ b/src/data/generated/data-features/ios-preference_daytime-night.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Preference daytime - Night","feature_key":"preference_daytime","property_key":"night","platform":"ios","amount":598159,"percentage":9.42}
+{"name":"Ios - Preference daytime - Night","feature_key":"preference_daytime","property_key":"night","platform":"ios","amount":599491,"percentage":9.44}

--- a/src/data/generated/data-features/ios-preference_daytime-night.json
+++ b/src/data/generated/data-features/ios-preference_daytime-night.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Preference daytime - Night","feature_key":"preference_daytime","property_key":"night","platform":"ios","amount":600474,"percentage":9.45}
+{"name":"Ios - Preference daytime - Night","feature_key":"preference_daytime","property_key":"night","platform":"ios","amount":601394,"percentage":9.46}

--- a/src/data/generated/data-features/ios-preference_daytime-night.json
+++ b/src/data/generated/data-features/ios-preference_daytime-night.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Preference daytime - Night","feature_key":"preference_daytime","property_key":"night","platform":"ios","amount":599491,"percentage":9.44}
+{"name":"Ios - Preference daytime - Night","feature_key":"preference_daytime","property_key":"night","platform":"ios","amount":600474,"percentage":9.45}

--- a/src/data/generated/data-features/ios-preference_daytime-night.json
+++ b/src/data/generated/data-features/ios-preference_daytime-night.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Preference daytime - Night","feature_key":"preference_daytime","property_key":"night","platform":"ios","amount":596964,"percentage":9.4}
+{"name":"Ios - Preference daytime - Night","feature_key":"preference_daytime","property_key":"night","platform":"ios","amount":598159,"percentage":9.42}

--- a/src/data/generated/data-features/ios-preference_daytime-twilight.json
+++ b/src/data/generated/data-features/ios-preference_daytime-twilight.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Preference daytime - Twilight","feature_key":"preference_daytime","property_key":"twilight","platform":"ios","amount":1095125,"percentage":16.62}
+{"name":"Ios - Preference daytime - Twilight","feature_key":"preference_daytime","property_key":"twilight","platform":"ios","amount":1095840,"percentage":16.62}

--- a/src/data/generated/data-features/ios-preference_daytime-twilight.json
+++ b/src/data/generated/data-features/ios-preference_daytime-twilight.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Preference daytime - Twilight","feature_key":"preference_daytime","property_key":"twilight","platform":"ios","amount":1097224,"percentage":16.64}
+{"name":"Ios - Preference daytime - Twilight","feature_key":"preference_daytime","property_key":"twilight","platform":"ios","amount":1099444,"percentage":16.66}

--- a/src/data/generated/data-features/ios-preference_daytime-twilight.json
+++ b/src/data/generated/data-features/ios-preference_daytime-twilight.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Preference daytime - Twilight","feature_key":"preference_daytime","property_key":"twilight","platform":"ios","amount":1095840,"percentage":16.62}
+{"name":"Ios - Preference daytime - Twilight","feature_key":"preference_daytime","property_key":"twilight","platform":"ios","amount":1097224,"percentage":16.64}

--- a/src/data/generated/data-features/ios-preference_daytime-twilight.json
+++ b/src/data/generated/data-features/ios-preference_daytime-twilight.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Preference daytime - Twilight","feature_key":"preference_daytime","property_key":"twilight","platform":"ios","amount":1099444,"percentage":16.66}
+{"name":"Ios - Preference daytime - Twilight","feature_key":"preference_daytime","property_key":"twilight","platform":"ios","amount":1101210,"percentage":16.69}

--- a/src/data/generated/data-features/ios-preference_daytime-unknown.json
+++ b/src/data/generated/data-features/ios-preference_daytime-unknown.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Preference daytime - Unknown","feature_key":"preference_daytime","property_key":"unknown","platform":"ios","amount":732020,"percentage":13.49}
+{"name":"Ios - Preference daytime - Unknown","feature_key":"preference_daytime","property_key":"unknown","platform":"ios","amount":731869,"percentage":13.49}

--- a/src/data/generated/data-features/ios-preference_daytime-unknown.json
+++ b/src/data/generated/data-features/ios-preference_daytime-unknown.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Preference daytime - Unknown","feature_key":"preference_daytime","property_key":"unknown","platform":"ios","amount":731686,"percentage":13.48}
+{"name":"Ios - Preference daytime - Unknown","feature_key":"preference_daytime","property_key":"unknown","platform":"ios","amount":731651,"percentage":13.48}

--- a/src/data/generated/data-features/ios-preference_daytime-unknown.json
+++ b/src/data/generated/data-features/ios-preference_daytime-unknown.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Preference daytime - Unknown","feature_key":"preference_daytime","property_key":"unknown","platform":"ios","amount":732078,"percentage":13.5}
+{"name":"Ios - Preference daytime - Unknown","feature_key":"preference_daytime","property_key":"unknown","platform":"ios","amount":732020,"percentage":13.49}

--- a/src/data/generated/data-features/ios-preference_daytime-unknown.json
+++ b/src/data/generated/data-features/ios-preference_daytime-unknown.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Preference daytime - Unknown","feature_key":"preference_daytime","property_key":"unknown","platform":"ios","amount":731869,"percentage":13.49}
+{"name":"Ios - Preference daytime - Unknown","feature_key":"preference_daytime","property_key":"unknown","platform":"ios","amount":731686,"percentage":13.48}

--- a/src/data/generated/data-features/ios-preference_ui_style-dark.json
+++ b/src/data/generated/data-features/ios-preference_ui_style-dark.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Preference ui style - Dark","feature_key":"preference_ui_style","property_key":"dark","platform":"ios","amount":1600225,"percentage":17.62}
+{"name":"Ios - Preference ui style - Dark","feature_key":"preference_ui_style","property_key":"dark","platform":"ios","amount":1600829,"percentage":17.63}

--- a/src/data/generated/data-features/ios-preference_ui_style-dark.json
+++ b/src/data/generated/data-features/ios-preference_ui_style-dark.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Preference ui style - Dark","feature_key":"preference_ui_style","property_key":"dark","platform":"ios","amount":1599870,"percentage":17.61}
+{"name":"Ios - Preference ui style - Dark","feature_key":"preference_ui_style","property_key":"dark","platform":"ios","amount":1600225,"percentage":17.62}

--- a/src/data/generated/data-features/ios-preference_ui_style-dark.json
+++ b/src/data/generated/data-features/ios-preference_ui_style-dark.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Preference ui style - Dark","feature_key":"preference_ui_style","property_key":"dark","platform":"ios","amount":1601535,"percentage":17.64}
+{"name":"Ios - Preference ui style - Dark","feature_key":"preference_ui_style","property_key":"dark","platform":"ios","amount":1602813,"percentage":17.68}

--- a/src/data/generated/data-features/ios-preference_ui_style-dark.json
+++ b/src/data/generated/data-features/ios-preference_ui_style-dark.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Preference ui style - Dark","feature_key":"preference_ui_style","property_key":"dark","platform":"ios","amount":1600829,"percentage":17.63}
+{"name":"Ios - Preference ui style - Dark","feature_key":"preference_ui_style","property_key":"dark","platform":"ios","amount":1601535,"percentage":17.64}

--- a/src/data/generated/data-features/ios-preference_ui_style-light.json
+++ b/src/data/generated/data-features/ios-preference_ui_style-light.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Preference ui style - Light","feature_key":"preference_ui_style","property_key":"light","platform":"ios","amount":4669101,"percentage":82.35}
+{"name":"Ios - Preference ui style - Light","feature_key":"preference_ui_style","property_key":"light","platform":"ios","amount":4668624,"percentage":82.32}

--- a/src/data/generated/data-features/ios-preference_ui_style-light.json
+++ b/src/data/generated/data-features/ios-preference_ui_style-light.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Preference ui style - Light","feature_key":"preference_ui_style","property_key":"light","platform":"ios","amount":4668715,"percentage":82.38}
+{"name":"Ios - Preference ui style - Light","feature_key":"preference_ui_style","property_key":"light","platform":"ios","amount":4668821,"percentage":82.38}

--- a/src/data/generated/data-features/ios-preference_ui_style-light.json
+++ b/src/data/generated/data-features/ios-preference_ui_style-light.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Preference ui style - Light","feature_key":"preference_ui_style","property_key":"light","platform":"ios","amount":4668821,"percentage":82.38}
+{"name":"Ios - Preference ui style - Light","feature_key":"preference_ui_style","property_key":"light","platform":"ios","amount":4669008,"percentage":82.37}

--- a/src/data/generated/data-features/ios-preference_ui_style-light.json
+++ b/src/data/generated/data-features/ios-preference_ui_style-light.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Preference ui style - Light","feature_key":"preference_ui_style","property_key":"light","platform":"ios","amount":4669008,"percentage":82.37}
+{"name":"Ios - Preference ui style - Light","feature_key":"preference_ui_style","property_key":"light","platform":"ios","amount":4669101,"percentage":82.35}

--- a/src/data/generated/data-features/ios-screen_scale-@2x.json
+++ b/src/data/generated/data-features/ios-screen_scale-@2x.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Screen scale - @2x","feature_key":"screen_scale","property_key":"@2x","platform":"ios","amount":2101756,"percentage":35.17}
+{"name":"Ios - Screen scale - @2x","feature_key":"screen_scale","property_key":"@2x","platform":"ios","amount":2102009,"percentage":35.17}

--- a/src/data/generated/data-features/ios-screen_scale-@2x.json
+++ b/src/data/generated/data-features/ios-screen_scale-@2x.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Screen scale - @2x","feature_key":"screen_scale","property_key":"@2x","platform":"ios","amount":2101181,"percentage":35.17}
+{"name":"Ios - Screen scale - @2x","feature_key":"screen_scale","property_key":"@2x","platform":"ios","amount":2101463,"percentage":35.17}

--- a/src/data/generated/data-features/ios-screen_scale-@2x.json
+++ b/src/data/generated/data-features/ios-screen_scale-@2x.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Screen scale - @2x","feature_key":"screen_scale","property_key":"@2x","platform":"ios","amount":2101041,"percentage":35.18}
+{"name":"Ios - Screen scale - @2x","feature_key":"screen_scale","property_key":"@2x","platform":"ios","amount":2101181,"percentage":35.17}

--- a/src/data/generated/data-features/ios-screen_scale-@2x.json
+++ b/src/data/generated/data-features/ios-screen_scale-@2x.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Screen scale - @2x","feature_key":"screen_scale","property_key":"@2x","platform":"ios","amount":2101463,"percentage":35.17}
+{"name":"Ios - Screen scale - @2x","feature_key":"screen_scale","property_key":"@2x","platform":"ios","amount":2101756,"percentage":35.17}

--- a/src/data/generated/data-features/ios-screen_scale-@3x.json
+++ b/src/data/generated/data-features/ios-screen_scale-@3x.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Screen scale - @3x","feature_key":"screen_scale","property_key":"@3x","platform":"ios","amount":4167543,"percentage":64.82}
+{"name":"Ios - Screen scale - @3x","feature_key":"screen_scale","property_key":"@3x","platform":"ios","amount":4167864,"percentage":64.83}

--- a/src/data/generated/data-features/ios-screen_scale-@3x.json
+++ b/src/data/generated/data-features/ios-screen_scale-@3x.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Screen scale - @3x","feature_key":"screen_scale","property_key":"@3x","platform":"ios","amount":4168879,"percentage":64.83}
+{"name":"Ios - Screen scale - @3x","feature_key":"screen_scale","property_key":"@3x","platform":"ios","amount":4169427,"percentage":64.83}

--- a/src/data/generated/data-features/ios-screen_scale-@3x.json
+++ b/src/data/generated/data-features/ios-screen_scale-@3x.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Screen scale - @3x","feature_key":"screen_scale","property_key":"@3x","platform":"ios","amount":4167864,"percentage":64.83}
+{"name":"Ios - Screen scale - @3x","feature_key":"screen_scale","property_key":"@3x","platform":"ios","amount":4168373,"percentage":64.83}

--- a/src/data/generated/data-features/ios-screen_scale-@3x.json
+++ b/src/data/generated/data-features/ios-screen_scale-@3x.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Screen scale - @3x","feature_key":"screen_scale","property_key":"@3x","platform":"ios","amount":4168373,"percentage":64.83}
+{"name":"Ios - Screen scale - @3x","feature_key":"screen_scale","property_key":"@3x","platform":"ios","amount":4168879,"percentage":64.83}

--- a/src/data/generated/data-features/ios-screen_zoomed-false.json
+++ b/src/data/generated/data-features/ios-screen_zoomed-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Screen zoomed - False","feature_key":"screen_zoomed","property_key":"false","platform":"ios","amount":5674855,"percentage":90.15}
+{"name":"Ios - Screen zoomed - False","feature_key":"screen_zoomed","property_key":"false","platform":"ios","amount":5675582,"percentage":90.15}

--- a/src/data/generated/data-features/ios-screen_zoomed-false.json
+++ b/src/data/generated/data-features/ios-screen_zoomed-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Screen zoomed - False","feature_key":"screen_zoomed","property_key":"false","platform":"ios","amount":5673372,"percentage":90.15}
+{"name":"Ios - Screen zoomed - False","feature_key":"screen_zoomed","property_key":"false","platform":"ios","amount":5674114,"percentage":90.15}

--- a/src/data/generated/data-features/ios-screen_zoomed-false.json
+++ b/src/data/generated/data-features/ios-screen_zoomed-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Screen zoomed - False","feature_key":"screen_zoomed","property_key":"false","platform":"ios","amount":5672936,"percentage":90.15}
+{"name":"Ios - Screen zoomed - False","feature_key":"screen_zoomed","property_key":"false","platform":"ios","amount":5673372,"percentage":90.15}

--- a/src/data/generated/data-features/ios-screen_zoomed-false.json
+++ b/src/data/generated/data-features/ios-screen_zoomed-false.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Screen zoomed - False","feature_key":"screen_zoomed","property_key":"false","platform":"ios","amount":5674114,"percentage":90.15}
+{"name":"Ios - Screen zoomed - False","feature_key":"screen_zoomed","property_key":"false","platform":"ios","amount":5674855,"percentage":90.15}

--- a/src/data/generated/data-features/ios-screen_zoomed-true.json
+++ b/src/data/generated/data-features/ios-screen_zoomed-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Screen zoomed - True","feature_key":"screen_zoomed","property_key":"true","platform":"ios","amount":595723,"percentage":9.85}
+{"name":"Ios - Screen zoomed - True","feature_key":"screen_zoomed","property_key":"true","platform":"ios","amount":595781,"percentage":9.85}

--- a/src/data/generated/data-features/ios-screen_zoomed-true.json
+++ b/src/data/generated/data-features/ios-screen_zoomed-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Screen zoomed - True","feature_key":"screen_zoomed","property_key":"true","platform":"ios","amount":595649,"percentage":9.85}
+{"name":"Ios - Screen zoomed - True","feature_key":"screen_zoomed","property_key":"true","platform":"ios","amount":595674,"percentage":9.85}

--- a/src/data/generated/data-features/ios-screen_zoomed-true.json
+++ b/src/data/generated/data-features/ios-screen_zoomed-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Screen zoomed - True","feature_key":"screen_zoomed","property_key":"true","platform":"ios","amount":595674,"percentage":9.85}
+{"name":"Ios - Screen zoomed - True","feature_key":"screen_zoomed","property_key":"true","platform":"ios","amount":595723,"percentage":9.85}

--- a/src/data/generated/data-features/ios-screen_zoomed-true.json
+++ b/src/data/generated/data-features/ios-screen_zoomed-true.json
@@ -1,1 +1,1 @@
-{"name":"Ios - Screen zoomed - True","feature_key":"screen_zoomed","property_key":"true","platform":"ios","amount":595781,"percentage":9.85}
+{"name":"Ios - Screen zoomed - True","feature_key":"screen_zoomed","property_key":"true","platform":"ios","amount":595855,"percentage":9.85}


### PR DESCRIPTION
# What does this PR do?
Change the colour for interpolated values in code blocks, so the text is visible in light mode. (https://github.com/appt-org/appt-website/issues/62)

## How do you test this PR?

Test link: http://localhost:3000/en/docs/swiftui/samples/accessibility-value

I haven't found any other code samples with an interpolation value, so I'm afraid we can only test the updated css with this doc. The text is rendered black on a white surface (light theme) and white on a black surface (dark theme), so I'm pretty sure this won't cause any problems whatsoever. 

Test steps:

* View in light mode
* View in dark mode
* Is everything readable?

## Checklist

- [ ] Works on Safari, Chrome, Firefox & Edge
- [ ] Works on different screen sizes (responsive)
- [ ] Scores 100 in [Lighthouse/PageSpeed Insights](https://pagespeed.web.dev) on SEO, accessibility and best practices, and >= 90 on performance
- [ ] Does not contain tracking cookies
- [ ] Are migrations added?
- [ ] Is the README.md updated?

## Accessibility checklist

- [ ] Scalable text
- [ ] Dark and light mode
- [ ] Contrast
- [ ] Focus management
- [ ] Aria attributes
