### PR TITLE
Fix color contrast issue in SwiftUI code snippets

### DIFF
--- a/src/css/prism/a11y-dark.css
+++ b/src/css/prism/a11y-dark.css
@@ -10,124 +10,128 @@
 /*
  Theme
  */
-[data-theme="dark"] code[class*="language-"],
-[data-theme="dark"] pre[class*="language-"] {
-  color: #ffffff!important;
+[data-theme='dark'] code[class*='language-'],
+[data-theme='dark'] pre[class*='language-'] {
+  color: #ffffff !important;
   background: none;
-  font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace!important;
-  font-size: 0.9rem!important;
-  text-align: left!important;
-  white-space: pre!important;
-  word-spacing: normal!important;
-  word-break: normal!important;
-  word-wrap: normal!important;
-  line-height: 1.5!important;
+  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace !important;
+  font-size: 0.9rem !important;
+  text-align: left !important;
+  white-space: pre !important;
+  word-spacing: normal !important;
+  word-break: normal !important;
+  word-wrap: normal !important;
+  line-height: 1.5 !important;
 
-  -moz-tab-size: 4!important;
-  -o-tab-size: 4!important;
-  tab-size: 4!important;
+  -moz-tab-size: 4 !important;
+  -o-tab-size: 4 !important;
+  tab-size: 4 !important;
 
-  -webkit-hyphens: none!important;
-  -moz-hyphens: none!important;
-  -ms-hyphens: none!important;
-  hyphens: none!important;
+  -webkit-hyphens: none !important;
+  -moz-hyphens: none !important;
+  -ms-hyphens: none !important;
+  hyphens: none !important;
 }
 
-[data-theme="dark"] .token.plain {
-  color: #ffffff!important;
+[data-theme='dark'] .token.plain {
+  color: #ffffff !important;
 }
 
-[data-theme="dark"] .token.comment {
-  font-size: 0.9rem!important;
+[data-theme='dark'] .token.comment {
+  font-size: 0.9rem !important;
 }
 
 /* Code blocks */
-[data-theme="dark"] pre[class*="language-"] {
-  padding: 1em!important;
-  margin: 0!important;
-  overflow: auto!important;
+[data-theme='dark'] pre[class*='language-'] {
+  padding: 1em !important;
+  margin: 0 !important;
+  overflow: auto !important;
 }
 
 /* Inline code */
-[data-theme="dark"] :not(pre) > code[class*="language-"] {
-  padding: 0.1em!important;
-  border-radius: 0.3em!important;
-  white-space: normal!important;
+[data-theme='dark'] :not(pre) > code[class*='language-'] {
+  padding: 0.1em !important;
+  border-radius: 0.3em !important;
+  white-space: normal !important;
 }
 
-[data-theme="dark"] .token.comment,
-[data-theme="dark"] .token.prolog,
-[data-theme="dark"] .token.doctype,
-[data-theme="dark"] .token.cdata {
-  color: #d4d0ab!important;
+[data-theme='dark'] .token.comment,
+[data-theme='dark'] .token.prolog,
+[data-theme='dark'] .token.doctype,
+[data-theme='dark'] .token.cdata {
+  color: #d4d0ab !important;
 }
 
-[data-theme="dark"] .token.punctuation {
-  color: #fefefe!important;
+[data-theme='dark'] .token.punctuation {
+  color: #fefefe !important;
 }
 
-[data-theme="dark"] .token.namespace {
-  opacity: 0.7!important;
+[data-theme='dark'] .token.namespace {
+  opacity: 0.7 !important;
 }
 
-[data-theme="dark"] .token.property,
-[data-theme="dark"] .token.tag,
-[data-theme="dark"] .token.constant,
-[data-theme="dark"] .token.class-name,
-[data-theme="dark"] .token.symbol,
-[data-theme="dark"] .token.deleted {
-  color: #ffa07a!important;
+[data-theme='dark'] .token.property,
+[data-theme='dark'] .token.tag,
+[data-theme='dark'] .token.constant,
+[data-theme='dark'] .token.class-name,
+[data-theme='dark'] .token.symbol,
+[data-theme='dark'] .token.deleted {
+  color: #ffa07a !important;
 }
 
-[data-theme="dark"] .token.boolean,
-[data-theme="dark"] .token.number {
-  color: #00e0e0!important;
+[data-theme='dark'] .token.boolean,
+[data-theme='dark'] .token.number {
+  color: #00e0e0 !important;
 }
 
-[data-theme="dark"] .token.selector,
-[data-theme="dark"] .token.attr-name,
-[data-theme="dark"] .token.string,
-[data-theme="dark"] .token.char,
-[data-theme="dark"] .token.builtin,
-[data-theme="dark"] .token.inserted {
-  color: #abe338!important;
+[data-theme='dark'] .token.selector,
+[data-theme='dark'] .token.attr-name,
+[data-theme='dark'] .token.string,
+[data-theme='dark'] .token.char,
+[data-theme='dark'] .token.builtin,
+[data-theme='dark'] .token.inserted {
+  color: #abe338 !important;
 }
 
-[data-theme="dark"] .token.operator,
-[data-theme="dark"] .token.entity,
-[data-theme="dark"] .token.url,
-[data-theme="dark"] .language-css .token.string,
-[data-theme="dark"] .style .token.string,
-[data-theme="dark"] .token.variable {
-  color: #00e0e0!important;
+[data-theme='dark'] .token.operator,
+[data-theme='dark'] .token.entity,
+[data-theme='dark'] .token.url,
+[data-theme='dark'] .language-css .token.string,
+[data-theme='dark'] .style .token.string,
+[data-theme='dark'] .token.variable {
+  color: #00e0e0 !important;
 }
 
-[data-theme="dark"] .token.atrule,
-[data-theme="dark"] .token.attr-value,
-[data-theme="dark"] .token.function {
-  color: #ffd700!important;
+[data-theme='dark'] .token.atrule,
+[data-theme='dark'] .token.attr-value,
+[data-theme='dark'] .token.function {
+  color: #ffd700 !important;
 }
 
-[data-theme="dark"] .token.keyword {
-  color: #00e0e0!important;
+[data-theme='dark'] .token.keyword {
+  color: #00e0e0 !important;
 }
 
-[data-theme="dark"] .token.regex,
-[data-theme="dark"] .token.important {
-  color: #ffd700!important;
+[data-theme='dark'] .token.regex,
+[data-theme='dark'] .token.important {
+  color: #ffd700 !important;
 }
 
-[data-theme="dark"] .token.important,
-[data-theme="dark"] .token.bold {
-  font-weight: bold!important;
+[data-theme='dark'] .token.important,
+[data-theme='dark'] .token.bold {
+  font-weight: bold !important;
 }
 
-[data-theme="dark"] .token.italic {
-  font-style: italic!important;
+[data-theme='dark'] .token.italic {
+  font-style: italic !important;
 }
 
-[data-theme="dark"] .token.entity {
-  cursor: help!important;
+[data-theme='dark'] .token.entity {
+  cursor: help !important;
+}
+
+[data-theme='dark'] .interpolation {
+  color: rgb(248, 248, 242);
 }
 
 /*
@@ -135,64 +139,64 @@
  */
 
 /* Line highlight */
-[data-theme="dark"] .line-highlight {
-  background: rgba(255, 217, 0, 0.1)!important;
-  border-top: 1px solid rgba(255, 217, 0, 0.55)!important;
-  border-bottom: 1px solid rgba(255, 217, 0, 0.55)!important;
+[data-theme='dark'] .line-highlight {
+  background: rgba(255, 217, 0, 0.1) !important;
+  border-top: 1px solid rgba(255, 217, 0, 0.55) !important;
+  border-bottom: 1px solid rgba(255, 217, 0, 0.55) !important;
 }
 
 /* Line numbers */
-[data-theme="dark"] .line-numbers .line-numbers-rows {
-  border-right: 1px solid #f8f8f2!important;
+[data-theme='dark'] .line-numbers .line-numbers-rows {
+  border-right: 1px solid #f8f8f2 !important;
 }
 
-[data-theme="dark"] .line-numbers-rows > span:before {
-  color: #d4d0ab!important;
+[data-theme='dark'] .line-numbers-rows > span:before {
+  color: #d4d0ab !important;
 }
 
 /*
  High contrast mode support
 */
 @media screen and (-ms-high-contrast: active) {
-  [data-theme="dark"] code[class*="language-"],
-  [data-theme="dark"] pre[class*="language-"] {
-    color: windowText!important;
-    background: window!important;
+  [data-theme='dark'] code[class*='language-'],
+  [data-theme='dark'] pre[class*='language-'] {
+    color: windowText !important;
+    background: window !important;
   }
 
-  [data-theme="dark"] :not(pre) > code[class*="language-"],
-  [data-theme="dark"] pre[class*="language-"] {
-    background: window!important;
+  [data-theme='dark'] :not(pre) > code[class*='language-'],
+  [data-theme='dark'] pre[class*='language-'] {
+    background: window !important;
   }
 
-  [data-theme="dark"] .token.important {
-    background: highlight!important;
-    color: window!important;
-    font-weight: normal!important;
+  [data-theme='dark'] .token.important {
+    background: highlight !important;
+    color: window !important;
+    font-weight: normal !important;
   }
 
-  [data-theme="dark"] .token.atrule,
-  [data-theme="dark"] .token.attr-value,
-  [data-theme="dark"] .token.function,
-  [data-theme="dark"] .token.keyword,
-  [data-theme="dark"] .token.operator,
-  [data-theme="dark"] .token.selector {
-    font-weight: bold!important;
+  [data-theme='dark'] .token.atrule,
+  [data-theme='dark'] .token.attr-value,
+  [data-theme='dark'] .token.function,
+  [data-theme='dark'] .token.keyword,
+  [data-theme='dark'] .token.operator,
+  [data-theme='dark'] .token.selector {
+    font-weight: bold !important;
   }
 
-  [data-theme="dark"] .token.attr-value,
-  [data-theme="dark"] .token.comment,
-  [data-theme="dark"] .token.doctype,
-  [data-theme="dark"] .token.function,
-  [data-theme="dark"] .token.keyword,
-  [data-theme="dark"] .token.operator,
-  [data-theme="dark"] .token.property,
-  [data-theme="dark"] .token.string {
-    color: highlight!important;
+  [data-theme='dark'] .token.attr-value,
+  [data-theme='dark'] .token.comment,
+  [data-theme='dark'] .token.doctype,
+  [data-theme='dark'] .token.function,
+  [data-theme='dark'] .token.keyword,
+  [data-theme='dark'] .token.operator,
+  [data-theme='dark'] .token.property,
+  [data-theme='dark'] .token.string {
+    color: highlight !important;
   }
 
-  [data-theme="dark"] .token.attr-value,
-  [data-theme="dark"] .token.url {
-    font-weight: normal!important;
+  [data-theme='dark'] .token.attr-value,
+  [data-theme='dark'] .token.url {
+    font-weight: normal !important;
   }
 }

--- a/src/css/prism/a11y-light.css
+++ b/src/css/prism/a11y-light.css
@@ -10,64 +10,64 @@
 /*
  Theme
  */
-code[class*="language-"],
-pre[class*="language-"] {
-  color: #202020!important;
-  background: none!important;
-  font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace!important;
-  font-size: 0.9rem!important;
-  text-align: left!important;
-  white-space: pre!important;
-  word-spacing: normal!important;
-  word-break: normal!important;
-  word-wrap: normal!important;
-  line-height: 1.5!important;
+code[class*='language-'],
+pre[class*='language-'] {
+  color: #202020 !important;
+  background: none !important;
+  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace !important;
+  font-size: 0.9rem !important;
+  text-align: left !important;
+  white-space: pre !important;
+  word-spacing: normal !important;
+  word-break: normal !important;
+  word-wrap: normal !important;
+  line-height: 1.5 !important;
 
-  -moz-tab-size: 4!important;
-  -o-tab-size: 4!important;
-  tab-size: 4!important;
+  -moz-tab-size: 4 !important;
+  -o-tab-size: 4 !important;
+  tab-size: 4 !important;
 
-  -webkit-hyphens: none!important;
-  -moz-hyphens: none!important;
-  -ms-hyphens: none!important;
-  hyphens: none!important;
+  -webkit-hyphens: none !important;
+  -moz-hyphens: none !important;
+  -ms-hyphens: none !important;
+  hyphens: none !important;
 }
 
 .token.plain {
-  color: #202020!important;
+  color: #202020 !important;
 }
 
 .token.comment {
-  font-size: 0.9rem!important;
+  font-size: 0.9rem !important;
 }
 
 /* Code blocks */
-pre[class*="language-"] {
-  padding: 1em!important;
-  margin: 0!important;
-  overflow: auto!important;
+pre[class*='language-'] {
+  padding: 1em !important;
+  margin: 0 !important;
+  overflow: auto !important;
 }
 
 /* Inline code */
-:not(pre) > code[class*="language-"] {
-  padding: 0.1em!important;
-  border-radius: 0.3em!important;
-  white-space: normal!important;
+:not(pre) > code[class*='language-'] {
+  padding: 0.1em !important;
+  border-radius: 0.3em !important;
+  white-space: normal !important;
 }
 
 .token.comment,
 .token.prolog,
 .token.doctype,
 .token.cdata {
-  color: #696969!important;
+  color: #696969 !important;
 }
 
 .token.punctuation {
-  color: #000000!important;
+  color: #000000 !important;
 }
 
 .token.namespace {
-  opacity: 0.7!important;
+  opacity: 0.7 !important;
 }
 
 .token.property,
@@ -76,12 +76,12 @@ pre[class*="language-"] {
 .token.class-name,
 .token.symbol,
 .token.deleted {
-  color: #007299!important;
+  color: #007299 !important;
 }
 
 .token.boolean,
 .token.number {
-  color: #008000!important;
+  color: #008000 !important;
 }
 
 .token.selector,
@@ -90,7 +90,7 @@ pre[class*="language-"] {
 .token.char,
 .token.builtin,
 .token.inserted {
-  color: #aa5d00!important;
+  color: #aa5d00 !important;
 }
 
 .token.operator,
@@ -99,35 +99,39 @@ pre[class*="language-"] {
 .language-css .token.string,
 .style .token.string,
 .token.variable {
-  color: #008000!important;
+  color: #008000 !important;
 }
 
 .token.atrule,
 .token.attr-value,
 .token.function {
-  color: #aa5d00!important;
+  color: #aa5d00 !important;
 }
 
 .token.keyword {
-  color: #d91e18!important;
+  color: #d91e18 !important;
 }
 
 .token.regex,
 .token.important {
-  color: #d91e18!important;
+  color: #d91e18 !important;
 }
 
 .token.important,
 .token.bold {
-  font-weight: bold!important;
+  font-weight: bold !important;
 }
 
 .token.italic {
-  font-style: italic!important;
+  font-style: italic !important;
 }
 
 .token.entity {
-  cursor: help!important;
+  cursor: help !important;
+}
+
+.interpolation {
+  color: rgb(7, 7, 13);
 }
 
 /*
@@ -136,39 +140,39 @@ pre[class*="language-"] {
 
 /* Line highlight */
 .line-highlight {
-  background: rgba(183, 134, 11, 0.075)!important;
-  border-top: 1px solid #b8860b!important;
-  border-bottom: 1px solid #b8860b!important;
+  background: rgba(183, 134, 11, 0.075) !important;
+  border-top: 1px solid #b8860b !important;
+  border-bottom: 1px solid #b8860b !important;
 }
 
 /* Line numbers */
 .line-numbers .line-numbers-rows {
-  border-right: 1px solid #aa5d00!important;
+  border-right: 1px solid #aa5d00 !important;
 }
 
 .line-numbers-rows > span:before {
-  color: #696969!important;
+  color: #696969 !important;
 }
 
 /*
  High contrast mode support
 */
 @media screen and (-ms-high-contrast: active) {
-  code[class*="language-"],
-  pre[class*="language-"] {
-    color: windowText!important;
-    background: window!important;
+  code[class*='language-'],
+  pre[class*='language-'] {
+    color: windowText !important;
+    background: window !important;
   }
 
-  :not(pre) > code[class*="language-"],
-  pre[class*="language-"] {
-    background: window!important;
+  :not(pre) > code[class*='language-'],
+  pre[class*='language-'] {
+    background: window !important;
   }
 
   .token.important {
-    background: highlight!important;
-    color: window!important;
-    font-weight: normal!important;
+    background: highlight !important;
+    color: window !important;
+    font-weight: normal !important;
   }
 
   .token.atrule,
@@ -177,7 +181,7 @@ pre[class*="language-"] {
   .token.keyword,
   .token.operator,
   .token.selector {
-    font-weight: bold!important;
+    font-weight: bold !important;
   }
 
   .token.attr-value,
@@ -188,11 +192,11 @@ pre[class*="language-"] {
   .token.operator,
   .token.property,
   .token.string {
-    color: highlight!important;
+    color: highlight !important;
   }
 
   .token.attr-value,
   .token.url {
-    font-weight: normal!important;
+    font-weight: normal !important;
   }
 }


### PR DESCRIPTION
# What does this PR do?
Change the colour for interpolated values in code blocks, so the text is visible in light mode. (https://github.com/appt-org/appt-website/issues/62)

## How do you test this PR?

Test link: http://localhost:3000/en/docs/swiftui/samples/accessibility-value

I haven't found any other code samples with an interpolation value, so I'm afraid we can only test the updated css with this doc. The text is rendered black on a white surface (light theme) and white on a black surface (dark theme), so I'm pretty sure this won't cause any problems whatsoever. 

Test steps:

* View in light mode
* View in dark mode
* Is everything readable?

## Checklist

- [ ] Works on Safari, Chrome, Firefox & Edge
- [ ] Works on different screen sizes (responsive)
- [ ] Scores 100 in [Lighthouse/PageSpeed Insights](https://pagespeed.web.dev) on SEO, accessibility and best practices, and >= 90 on performance
- [ ] Does not contain tracking cookies
- [ ] Are migrations added?
- [ ] Is the README.md updated?

## Accessibility checklist

- [ ] Scalable text
- [ ] Dark and light mode
- [ ] Contrast
- [ ] Focus management
- [ ] Aria attributes
