### PR TITLE
Update Flutter documentation to replace deprecated `textScaleFactor` with `textScaler`

### DIFF
--- a/src/data/code-samples/en/text-scale/flutter.md
+++ b/src/data/code-samples/en/text-scale/flutter.md
@@ -2,20 +2,29 @@
 
 Flutter automatically scales the text on the screen to the text size set by the user. We recommend using [`ThemeData`](https://api.flutter.dev/flutter/material/ThemeData-class.html) to use the same text sizes and fonts everywhere.
 
-Try to avoid using the `textScaleFactor` property because it overrides the text scale factor preferred by the user. The default factor is `1.0`, but can go as high as `4.0` for some users. Restricting the number means that some users might not be able to read the text.
+Try to avoid using the setter of `textScaler` property because it overrides the text scale factor preferred by the user. The default factor is `1.0`, but can go as high as `4.0` for some users. Restricting the number means that some users might not be able to read the text.
 
-There are valid use cases to restrict the `textScaleFactor` to a certain number. You can use [`MediaQuery`](https://api.flutter.dev/flutter/widgets/MediaQuery-class.html) to override the value globally. You can also override it for a single use case by using the property inside a [`Text`](https://api.flutter.dev/flutter/widgets/Text-class.html) widget.
+There are valid use cases to restrict the text scale to a certain number. You can use [`MediaQuery`](https://api.flutter.dev/flutter/widgets/MediaQuery-class.html) to override the value globally. You can also override it for a single use case by using the property inside a [`Text`](https://api.flutter.dev/flutter/widgets/Text-class.html) widget.
 
 ```dart
+// Override scale for all widgets
 MediaQuery(
   data: MediaQuery.of(context).copyWith(
-    textScaleFactor: 1.0, // Override scale for all widgets
+    textScaler: const TextScaler.linear(1.0)
+    // or
+    textScaler:  TextScaler.noScaling, 
   ),
   child: ...,
 );
+//or even shorter
+MediaQuery.withNoTextScaling(
+  child: ...,
+)
 
+// Override scale for a single widget
 Text(
   'Appt', 
-  textScaleFactor: 1.0, // Override scale for a single widget
+  textScaler: TextScaler.noScaling, 
 );
 ```
+


### PR DESCRIPTION
Hi, 

First of all, thank you for this website. It provides a huge amount of knowledge. I've just started to learn how to implement accessibility, and your documentation helps me a lot.

I've noticed the Flutter doc shows deprecated API and thought I could prepare that small update. Here's the link https://docs.flutter.dev/release/breaking-changes/deprecate-textscalefactor

